### PR TITLE
Add configurable MusicXML whole-rest positioning

### DIFF
--- a/include/denigma/formats/musicxml.h
+++ b/include/denigma/formats/musicxml.h
@@ -37,6 +37,9 @@ struct Options final : public IOptions
     /// Options common to all converters.
     CommonOptions common;
     bool includeTempoTool{ false };
+    /// Shift non-floating whole rests to the SMuFL glyph-origin position.
+    /// Preserve Finale's nominal position for non-floating whole rests instead of using the SMuFL default.
+    bool useFinaleRestPosition{ false };
     /// Optional 1-based Finale layer to treat as cue material in addition to automatically detected cues.
     std::optional<int> cueLayer;
     /// Emit the score plus all linked parts for multi-output conversion.

--- a/src/core/denigma.cpp
+++ b/src/core/denigma.cpp
@@ -159,6 +159,10 @@ std::vector<const arg_char*> DenigmaContext::parseOptions(int argc, arg_char* ar
             noValidate = true;
         } else if (next == _ARG("--all-fonts-available")) {
             allFontsAvailable = true;
+        } else if (next == _ARG("--smufl-rest-position")) {
+            useFinaleRestPosition = false;
+        } else if (next == _ARG("--finale-rest-position")) {
+            useFinaleRestPosition = true;
         } else if (next == _ARG("--cue-layer")) {
             const std::string layerValue = std::string(_ARG_CONV(getNextArg()));
             if (layerValue.empty()) {

--- a/src/core/denigma.h
+++ b/src/core/denigma.h
@@ -251,6 +251,7 @@ public:
     bool quiet{};
     bool noValidate{};
     bool allFontsAvailable{};
+    bool useFinaleRestPosition{};
     std::optional<int> cueLayer;
     std::optional<std::filesystem::path> excludeFolder;
     std::optional<std::string> partName;

--- a/src/export/export.cpp
+++ b/src/export/export.cpp
@@ -75,6 +75,7 @@ formats::musicxml::Options makeMusicXmlOptions(const DenigmaContext& denigmaCont
     formats::musicxml::Options options;
     options.common = makeCommonOptions(denigmaContext);
     options.includeTempoTool = denigmaContext.includeTempoTool;
+    options.useFinaleRestPosition = denigmaContext.useFinaleRestPosition;
     options.cueLayer = denigmaContext.cueLayer;
     options.allPartsAndScore = denigmaContext.allPartsAndScore;
     options.partName = denigmaContext.partName;
@@ -390,6 +391,8 @@ int ExportCommand::showHelpPage(const std::string_view& programName, const std::
     std::cout << indentSpaces << "Specific options:" << std::endl;
     std::cout << indentSpaces << "  --all-fonts-available          Tells " << DENIGMA_NAME
               << " that every source font will be available when the output is read." << std::endl;
+    std::cout << indentSpaces << "  --smufl-rest-position          Shift non-floating whole rests to the SMuFL glyph-origin position (default)." << std::endl;
+    std::cout << indentSpaces << "  --finale-rest-position         Preserve Finale's nominal position for non-floating whole rests." << std::endl;
     std::cout << indentSpaces << "  --cue-layer <1..4>              Treat entries in this Finale layer as cue material." << std::endl;
     std::cout << indentSpaces << "  --mnx-schema [file-path]        Validate against this json schema file rather than the embedded one." << std::endl;
     std::cout << indentSpaces << "  --include-tempo-tool            Include tempo changes created with the Tempo Tool." << std::endl;

--- a/src/formats/musicxml/design-decisions.md
+++ b/src/formats/musicxml/design-decisions.md
@@ -74,7 +74,7 @@ An explicitly positioned rest is the opposite case. There the author overrode th
 
 Finale's own export writes a resolved position for every rest, floating or not, which discards the distinction entirely.
 
-The separate question of whether an explicitly positioned rest's display pitch means Finale's nominal position or the SMuFL glyph origin is unsettled in MusicXML itself; see the whole-rest position item in the [roadmap](roadmap.md).
+The exporter defaults to the SMuFL glyph-origin convention for non-floating whole rests, which shifts the display pitch upward by one staff space. The `--finale-rest-position` option preserves Finale's nominal position for compatibility.
 
 ### Lyric verse numbers carry their Finale lyric type
 

--- a/src/formats/musicxml/musicxml_converter.cpp
+++ b/src/formats/musicxml/musicxml_converter.cpp
@@ -54,6 +54,7 @@ DenigmaContext makeMusicXmlContext(const Options& options, const std::filesystem
     context.verbose = options.common.verbose;
     context.quiet = options.common.quiet;
     context.allFontsAvailable = options.common.allFontsAvailable;
+    context.useFinaleRestPosition = options.useFinaleRestPosition;
     context.includeTempoTool = options.includeTempoTool;
     context.cueLayer = options.cueLayer;
     context.allPartsAndScore = options.allPartsAndScore;

--- a/src/formats/musicxml/musicxml_notes.cpp
+++ b/src/formats/musicxml/musicxml_notes.cpp
@@ -210,7 +210,7 @@ void applyTupletData(mx::api::NoteData& note, const EntryInfoPtr& entryInfo)
     }
 }
 
-void applyRestPositionIfNeeded(mx::api::NoteData& rest, const EntryInfoPtr& entryInfo)
+void applyRestPositionIfNeeded(const MusicXmlMusxMapping& context, mx::api::NoteData& rest, const EntryInfoPtr& entryInfo)
 {
     if (!entryInfo) {
         return;
@@ -223,11 +223,24 @@ void applyRestPositionIfNeeded(mx::api::NoteData& rest, const EntryInfoPtr& entr
     if (restNoteInfo->getNoteId() != Note::RESTID) {
         return;
     }
-    const auto [noteName, octave, alteration, staffPosition] = restNoteInfo.calcNotePropertiesInView();
+    auto [noteName, octave, alteration, staffPosition] = restNoteInfo.calcNotePropertiesInView();
     (void)alteration;
+    const auto restPositionOffset = calcFinaleToSmuflRestPositionOffset(NoteType::Whole);
+    if (!context.denigmaContext->useFinaleRestPosition
+        && rest.durationData.durationName == mx::api::DurationName::whole
+        && restPositionOffset != 0) {
+        staffPosition += restPositionOffset;
+        switch (noteName) {
+        case music_theory::NoteName::A: noteName = music_theory::NoteName::C; ++octave; break;
+        case music_theory::NoteName::B: noteName = music_theory::NoteName::D; ++octave; break;
+        case music_theory::NoteName::C: noteName = music_theory::NoteName::E; break;
+        case music_theory::NoteName::D: noteName = music_theory::NoteName::F; break;
+        case music_theory::NoteName::E: noteName = music_theory::NoteName::G; break;
+        case music_theory::NoteName::F: noteName = music_theory::NoteName::A; break;
+        case music_theory::NoteName::G: noteName = music_theory::NoteName::B; break;
+        }
+    }
     (void)staffPosition;
-    /// @todo Add a MusicXML option that applies calcFinaleToSmuflRestPositionOffset to the display pitch.
-    /// MusicXML does not specify whether rest display position is the nominal position or the SMuFL glyph origin.
     rest.isDisplayStepOctaveSpecified = true;
     rest.pitchData = mx::api::PitchData(enumConvert<mx::api::Step>(noteName), 0, octave);
 }
@@ -446,7 +459,7 @@ mx::api::NoteData createRestData(
     if (entryInfo) {
         rest.beams = createBeamData(context, entryInfo);
         applyTupletData(rest, entryInfo);
-        applyRestPositionIfNeeded(rest, entryInfo);
+        applyRestPositionIfNeeded(context, rest, entryInfo);
         processArticulations(context, staff, rest, entryInfo, isStaffValueSpecified);
         if (entryIt.getEffectiveHidden() || (effectiveStaff && effectiveStaff->hideRests)) {
             rest.printData.printObject = mx::api::Bool::no;

--- a/src/formats/musicxml/roadmap.md
+++ b/src/formats/musicxml/roadmap.md
@@ -8,12 +8,6 @@ Export standards-compliant compressed MusicXML in addition to uncompressed `.mus
 
 Initially, write one `.mxl` archive for each score or part document that Denigma currently emits separately. Packaging the score and all linked parts into one MusicXML 4.0 archive through `<part-link>` can be considered as a later extension rather than a prerequisite for basic compressed output.
 
-## Whole-rest position convention
-
-Add a MusicXML export option that selects whether an explicitly positioned whole rest preserves Finale's nominal rest position or shifts upward one staff space to the SMuFL glyph origin. MusicXML does not define which interpretation `<display-step>` and `<display-octave>` require; see [MusicXML issue #681](https://github.com/w3c-cg/musicxml/issues/681) and its predecessor, [issue #5](https://github.com/w3c-cg/musicxml/issues/5).
-
-The default should remain Finale-compatible and apply no adjustment, matching round trips through Finale and MuseScore. The optional SMuFL-origin behavior should use `calcFinaleToSmuflRestPositionOffset`, matching Dorico's current interpretation. Apply the selected convention consistently to ordinary and complete-measure whole rests; other rest durations are unaffected.
-
 ## Microtonal key signatures
 
 Extend the nontraditional key-signature mapping to microtonal signatures by converting Finale's EDO divisions into MusicXML semitone alterations and suitable accidental values. Preserve the effective written or concert-pitch signature independently for each staff, as the exporter already does for traditional keys.

--- a/tests/musicxml/musicxml_test.cpp
+++ b/tests/musicxml/musicxml_test.cpp
@@ -28,12 +28,15 @@
 
 namespace denigma::test::musicxml {
 
-std::filesystem::path exportMusicXmlFixture(const std::string& musxFile)
+std::filesystem::path exportMusicXmlFixture(const std::string& musxFile, bool useFinaleRestPosition)
 {
     std::filesystem::path inputPath;
     copyInputToOutput(musxFile, inputPath);
 
     ArgList args = { DENIGMA_NAME, "export", pathString(inputPath), "--musicxml" };
+    if (useFinaleRestPosition) {
+        args.add("--finale-rest-position");
+    }
     checkStderr({ "Processing", pathString(inputPath.filename()) }, [&]() {
         EXPECT_EQ(denigmaTestMain(args.argc(), args.argv()), 0) << "export to musicxml: " << pathString(inputPath);
     });

--- a/tests/musicxml/musicxml_test.h
+++ b/tests/musicxml/musicxml_test.h
@@ -27,7 +27,7 @@
 
 namespace denigma::test::musicxml {
 
-std::filesystem::path exportMusicXmlFixture(const std::string& musxFile);
+std::filesystem::path exportMusicXmlFixture(const std::string& musxFile, bool useFinaleRestPosition = false);
 std::optional<mx::api::ScoreData> createScoreDataFromMusicXmlFixture(const std::string& musxFile);
 std::optional<mx::api::ScoreData> createScoreDataFromMusxPath(const std::filesystem::path& musxPath);
 std::optional<mx::api::ScoreData> loadScoreData(const std::filesystem::path& path);

--- a/tests/musicxml/test_notes.cpp
+++ b/tests/musicxml/test_notes.cpp
@@ -1267,7 +1267,7 @@ TEST(MusicXmlNotes, VoicesKeyboardUsesStaffQualifiedVoiceNumbers)
 {
     setupTestDataPaths();
 
-    const auto outputPath = exportMusicXmlFixture("voices_keyboard.musx");
+    const auto outputPath = exportMusicXmlFixture("voices_keyboard.musx", true);
     const auto actualScore = loadScoreData(outputPath);
     ASSERT_TRUE(actualScore);
 

--- a/tests/musicxml/test_notes.cpp
+++ b/tests/musicxml/test_notes.cpp
@@ -901,7 +901,7 @@ TEST(MusicXmlNotes, WholeRestPositionsMatchFinale)
 {
     setupTestDataPaths();
 
-    const auto outputPath = exportMusicXmlFixture("whole_rests.musx");
+    const auto outputPath = exportMusicXmlFixture("whole_rests.musx", true);
     const auto actualScore = loadScoreData(outputPath);
     const auto expectedScore = loadScoreData(getInputPath() / "musicxml/whole_rests-ref.musicxml");
     ASSERT_TRUE(actualScore);
@@ -917,6 +917,26 @@ TEST(MusicXmlNotes, WholeRestPositionsMatchFinale)
         { mx::api::Step::g, 4 },
     };
     EXPECT_EQ(positionedRestDisplayPitches(*expectedScore), expectedPositions);
+    EXPECT_EQ(positionedRestDisplayPitches(*actualScore), expectedPositions);
+}
+
+TEST(MusicXmlNotes, WholeRestPositionsUseSmuflConventionByDefault)
+{
+    setupTestDataPaths();
+
+    const auto outputPath = exportMusicXmlFixture("whole_rests.musx");
+    const auto actualScore = loadScoreData(outputPath);
+    ASSERT_TRUE(actualScore);
+
+    const std::vector<std::pair<mx::api::Step, int>> expectedPositions{
+        { mx::api::Step::a, 5 },
+        { mx::api::Step::f, 5 },
+        { mx::api::Step::d, 5 },
+        { mx::api::Step::b, 4 },
+        { mx::api::Step::g, 4 },
+        { mx::api::Step::e, 4 },
+        { mx::api::Step::b, 4 },
+    };
     EXPECT_EQ(positionedRestDisplayPitches(*actualScore), expectedPositions);
 }
 

--- a/tests/test_options.cpp
+++ b/tests/test_options.cpp
@@ -271,6 +271,22 @@ TEST(Options, ParseOptions)
     }
     {
         static const std::string fileName = "notAscii-其れ";
+        ArgList args = { DENIGMA_NAME, "--testing", "export", fileName + ".musx", "--musicxml", "--smufl-rest-position" };
+        DenigmaContext ctx(DENIGMA_NAME);
+        auto newArgs = ctx.parseOptions(args.argc(), args.argv());
+        EXPECT_EQ(newArgs.size(), 3);
+        EXPECT_FALSE(ctx.useFinaleRestPosition);
+    }
+    {
+        static const std::string fileName = "notAscii-其れ";
+        ArgList args = { DENIGMA_NAME, "--testing", "export", fileName + ".musx", "--musicxml", "--finale-rest-position" };
+        DenigmaContext ctx(DENIGMA_NAME);
+        auto newArgs = ctx.parseOptions(args.argc(), args.argv());
+        EXPECT_EQ(newArgs.size(), 3);
+        EXPECT_TRUE(ctx.useFinaleRestPosition);
+    }
+    {
+        static const std::string fileName = "notAscii-其れ";
         ArgList args = { DENIGMA_NAME, "--testing", "export", fileName + ".musx", "--svg", "--shape-def", "3,5", "--shape-def", "5,7",
                          "--svg-unit", "px", "--no-svg-page-scale", "--svg-scale", "1.25" };
         DenigmaContext ctx(DENIGMA_NAME);


### PR DESCRIPTION
## Summary
- add `--smufl-rest-position` (default) and `--finale-rest-position` MusicXML options
- shift whole-rest display pitches to the SMuFL glyph-origin convention by default
- preserve Finale-compatible positions when explicitly requested
- add option parsing and MusicXML regression coverage

## Tests
- Existing targeted tests were completed before this commit.