### PR TITLE
Improve the public CMake conversion API

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,9 @@ cmake_minimum_required(VERSION 3.22)
 # Project name and version
 project(denigma VERSION 4.0.0)
 
+option(denigma_BUILD_CLI "Build the Denigma command-line application" ${PROJECT_IS_TOP_LEVEL})
+option(denigma_BUILD_TESTING "Build the Denigma test suite" ${PROJECT_IS_TOP_LEVEL})
+
 # Specify C++ standard and minimum macOS version
 set(DENIGMA_CXX_STANDARD "23" CACHE STRING "C++ standard used to build Denigma; must be at least 20")
 set_property(CACHE DENIGMA_CXX_STANDARD PROPERTY STRINGS 20 23 26)
@@ -319,57 +322,59 @@ function(add_denigma_internal_test_library target_name)
     target_compile_definitions(${target_name} PRIVATE DENIGMA_TEST)
 endfunction()
 
-option(denigma_BUILD_TESTING "Build the Denigma test suite" ON)
-
 add_subdirectory(src)
 
-include("${PROJECT_SOURCE_DIR}/cmake/GenerateLicenseXxd.cmake")
-
-# Add executable target
-add_executable(denigma
-    src/main.cpp
-    src/about.cpp
-)
-target_compile_options(denigma PRIVATE ${DENIGMA_WARNING_OPTIONS})
-
-# For the denigma target specifically
-if (NOT CMAKE_CONFIGURATION_TYPES) # Only applies to single-config generators
-    set_target_properties(denigma PROPERTIES
-        RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/build/${CMAKE_BUILD_TYPE}
-    )
+if(denigma_BUILD_CLI OR denigma_BUILD_TESTING)
+    include("${PROJECT_SOURCE_DIR}/cmake/GenerateLicenseXxd.cmake")
 endif()
 
-# Ensure the include directories are added
-add_dependencies(denigma GenerateLicenseXxd)
-target_link_libraries(denigma PRIVATE
-    denigma_export
-    denigma_massage
-    denigma_internal_deps
-)
-if(DENIGMA_HAS_FREETYPE_LICENSE)
-    target_compile_definitions(denigma PRIVATE DENIGMA_HAS_FREETYPE_LICENSE=1)
-endif()
-
-set(DEPLOY_DIR ${CMAKE_CURRENT_SOURCE_DIR}/denigma)
-
-if(CMAKE_GENERATOR MATCHES "^Visual Studio")
-    add_custom_command(
-        TARGET denigma
-        POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E make_directory ${DEPLOY_DIR}
-        COMMAND cmd.exe /c if "$(Configuration)" == "Release" echo Copying Release build of denigma to deploy directory
-        COMMAND cmd.exe /c if "$(Configuration)" == "Release" "${CMAKE_COMMAND}" -E copy_if_different "$<TARGET_FILE:denigma>" "${DEPLOY_DIR}"
+if(denigma_BUILD_CLI)
+    # Add executable target
+    add_executable(denigma
+        src/main.cpp
+        src/about.cpp
     )
-elseif (CMAKE_BUILD_TYPE STREQUAL "Release")
-    message(STATUS "Configuring POST_BUILD command for Release.")
-    add_custom_command(
-        TARGET denigma
-        POST_BUILD
-        COMMAND echo Copying Release build of denigma to deploy directory
-        COMMAND ${CMAKE_COMMAND} -E make_directory ${DEPLOY_DIR}
-        COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:denigma> ${DEPLOY_DIR}
-        VERBATIM
+    target_compile_options(denigma PRIVATE ${DENIGMA_WARNING_OPTIONS})
+
+    # For the denigma target specifically
+    if (NOT CMAKE_CONFIGURATION_TYPES) # Only applies to single-config generators
+        set_target_properties(denigma PROPERTIES
+            RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/build/${CMAKE_BUILD_TYPE}
+        )
+    endif()
+
+    # Ensure the include directories are added
+    add_dependencies(denigma GenerateLicenseXxd)
+    target_link_libraries(denigma PRIVATE
+        denigma_export
+        denigma_massage
+        denigma_internal_deps
     )
+    if(DENIGMA_HAS_FREETYPE_LICENSE)
+        target_compile_definitions(denigma PRIVATE DENIGMA_HAS_FREETYPE_LICENSE=1)
+    endif()
+
+    set(DEPLOY_DIR ${CMAKE_CURRENT_SOURCE_DIR}/denigma)
+
+    if(CMAKE_GENERATOR MATCHES "^Visual Studio")
+        add_custom_command(
+            TARGET denigma
+            POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E make_directory ${DEPLOY_DIR}
+            COMMAND cmd.exe /c if "$(Configuration)" == "Release" echo Copying Release build of denigma to deploy directory
+            COMMAND cmd.exe /c if "$(Configuration)" == "Release" "${CMAKE_COMMAND}" -E copy_if_different "$<TARGET_FILE:denigma>" "${DEPLOY_DIR}"
+        )
+    elseif (CMAKE_BUILD_TYPE STREQUAL "Release")
+        message(STATUS "Configuring POST_BUILD command for Release.")
+        add_custom_command(
+            TARGET denigma
+            POST_BUILD
+            COMMAND echo Copying Release build of denigma to deploy directory
+            COMMAND ${CMAKE_COMMAND} -E make_directory ${DEPLOY_DIR}
+            COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:denigma> ${DEPLOY_DIR}
+            VERBATIM
+        )
+    endif()
 endif()
 
 if(denigma_BUILD_TESTING)

--- a/README.md
+++ b/README.md
@@ -37,6 +37,27 @@ target_link_libraries(my_tool PRIVATE denigma::enigmaxml)
 
 Use `denigma::classify` when you only need classification helpers. Use one of the format targets when you need a specific converter.
 
+Register the linked formats and call `ConverterRegistry::convert` when the application needs runtime format selection or owned output buffers:
+
+```cpp
+#include "denigma/formats/mnx.h"
+
+denigma::ConverterRegistry registry;
+denigma::formats::mnx::registerConverters(registry);
+
+denigma::BufferRandomAccessReader input(musxBytes);
+denigma::formats::mnx::Options options;
+options.common.sourceName = "score.musx";
+
+auto artifact = registry.convert(
+	denigma::FormatId::Musx,
+	denigma::FormatId::MnxJson,
+	input,
+	denigma::ConversionRequest{ &options });
+```
+
+`ConversionArtifact` owns the generated documents in emission order and preserves the converter's `ConversionResult`. Multi-output converters retain each suggested filename. Applications that know their converter at compile time may continue using its typed `convert` overload directly.
+
 The companion [denigma-examples](https://github.com/rpatters1/denigma-examples) repository demonstrates this from separate native and WebAssembly projects using CMake `FetchContent` or a local Denigma checkout.
 
 When Denigma is added as a CMake subproject, its CLI and tests are disabled by default. Consumers can override either option before making Denigma available:

--- a/README.md
+++ b/README.md
@@ -39,6 +39,23 @@ Use `denigma::classify` when you only need classification helpers. Use one of th
 
 The companion [denigma-examples](https://github.com/rpatters1/denigma-examples) repository demonstrates this from separate native and WebAssembly projects using CMake `FetchContent` or a local Denigma checkout.
 
+When Denigma is added as a CMake subproject, its CLI and tests are disabled by default. Consumers can override either option before making Denigma available:
+
+```cmake
+set(denigma_BUILD_CLI OFF CACHE BOOL "" FORCE)
+set(denigma_BUILD_TESTING OFF CACHE BOOL "" FORCE)
+
+include(FetchContent)
+FetchContent_Declare(
+	denigma
+	GIT_REPOSITORY https://github.com/rpatters1/denigma.git
+	GIT_TAG        <release-tag-or-commit>
+)
+FetchContent_MakeAvailable(denigma)
+```
+
+Standalone Denigma builds continue to build the CLI and tests by default.
+
 ## Command line usage
 
 Use the `--help` option to get a full list of commands:

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ target_link_libraries(my_tool PRIVATE denigma::enigmaxml)
 
 Use `denigma::classify` when you only need classification helpers. Use one of the format targets when you need a specific converter.
 
-Register the linked formats and call `ConverterRegistry::convert` when the application needs runtime format selection or owned output buffers:
+Applications may register linked formats and call `ConverterRegistry::convert` when runtime format selection or owned output buffers are useful:
 
 ```cpp
 #include "denigma/formats/mnx.h"
@@ -56,7 +56,7 @@ auto artifact = registry.convert(
 	denigma::ConversionRequest{ &options });
 ```
 
-`ConversionArtifact` owns the generated documents in emission order and preserves the converter's `ConversionResult`. Multi-output converters retain each suggested filename. Applications that know their converter at compile time may continue using its typed `convert` overload directly.
+`ConversionArtifact` owns the generated documents in emission order and preserves the converter's `ConversionResult`. Multi-output converters retain each suggested filename. The format-specific typed converters and their `convert` overloads remain a first-class alternative.
 
 The companion [denigma-examples](https://github.com/rpatters1/denigma-examples) repository demonstrates this from separate native and WebAssembly projects using CMake `FetchContent` or a local Denigma checkout.
 

--- a/include/denigma/conversion.h
+++ b/include/denigma/conversion.h
@@ -23,15 +23,17 @@
 
 #include <cassert>
 #include <cstddef>
+#include <cstring>
 #include <functional>
 #include <memory>
 #include <ostream>
+#include <sstream>
 #include <span>
 #include <stdexcept>
 #include <string>
 #include <string_view>
-#include <vector>
 #include <utility>
+#include <vector>
 
 #include "denigma/io/random_access_reader.h"
 
@@ -142,6 +144,56 @@ public:
 private:
     std::vector<Diagnostic> m_diagnostics;
     bool m_hasError{};
+};
+
+/// @struct ConversionOutput
+/// @brief One document produced by a conversion.
+struct ConversionOutput
+{
+    /// Suggested output filename. Empty when the converter does not supply one.
+    std::string suggestedName;
+    /// Owned output bytes.
+    std::vector<std::byte> data;
+};
+
+/// @class ConversionArtifact
+/// @brief Owned documents and result metadata from one conversion.
+class ConversionArtifact
+{
+public:
+    /// Creates an artifact from converter result metadata and generated documents.
+    ConversionArtifact(ConversionResult result, std::vector<ConversionOutput> outputs)
+        : m_result(std::move(result)), m_outputs(std::move(outputs))
+    {
+    }
+
+    /// Returns converter result metadata.
+    [[nodiscard]] const ConversionResult& result() const noexcept
+    {
+        return m_result;
+    }
+
+    /// Returns the generated documents in converter emission order.
+    [[nodiscard]] std::span<const ConversionOutput> outputs() const noexcept
+    {
+        return m_outputs;
+    }
+
+    /// Returns true when the conversion result contains an error diagnostic.
+    [[nodiscard]] bool hasError() const noexcept
+    {
+        return m_result.hasError();
+    }
+
+    /// Returns true when the conversion completed without an error diagnostic.
+    explicit operator bool() const noexcept
+    {
+        return static_cast<bool>(m_result);
+    }
+
+private:
+    ConversionResult m_result;
+    std::vector<ConversionOutput> m_outputs;
 };
 
 /// @brief Returns typed options from an erased request, or default options when none were supplied.
@@ -320,7 +372,77 @@ public:
         return nullptr;
     }
 
+    /// Converts an in-memory input with the registered adapter for the requested formats.
+    /// Returns an error diagnostic when no matching adapter is registered.
+    [[nodiscard]] ConversionArtifact convert(FormatId sourceFormat,
+                                             FormatId targetFormat,
+                                             std::span<const std::byte> input,
+                                             const ConversionRequest& request = {}) const
+    {
+        if (const auto* converter = find(sourceFormat, targetFormat)) {
+            return collectSingleOutput(*converter, input, request);
+        }
+        if (const auto* converter = findMultiOutput(sourceFormat, targetFormat)) {
+            return collectMultipleOutputs(*converter, input, request);
+        }
+        return unsupportedConversion();
+    }
+
+    /// Converts a random-access input with the registered adapter for the requested formats.
+    /// Returns an error diagnostic when no matching adapter is registered.
+    [[nodiscard]] ConversionArtifact convert(FormatId sourceFormat,
+                                             FormatId targetFormat,
+                                             const IRandomAccessReader& input,
+                                             const ConversionRequest& request = {}) const
+    {
+        if (const auto* converter = findReader(sourceFormat, targetFormat)) {
+            return collectSingleOutput(*converter, input, request);
+        }
+        if (const auto* converter = findReaderMultiOutput(sourceFormat, targetFormat)) {
+            return collectMultipleOutputs(*converter, input, request);
+        }
+        return unsupportedConversion();
+    }
+
 private:
+    template <typename Converter, typename Input>
+    static ConversionArtifact collectSingleOutput(const Converter& converter,
+                                                   const Input& input,
+                                                   const ConversionRequest& request)
+    {
+        std::ostringstream output;
+        auto result = converter.convert(input, output, request);
+        auto text = output.str();
+        std::vector<std::byte> data(text.size());
+        if (!text.empty()) {
+            std::memcpy(data.data(), text.data(), text.size());
+        }
+        std::vector<ConversionOutput> outputs;
+        if (!data.empty()) {
+            outputs.push_back({ {}, std::move(data) });
+        }
+        return { std::move(result), std::move(outputs) };
+    }
+
+    template <typename Converter, typename Input>
+    static ConversionArtifact collectMultipleOutputs(const Converter& converter,
+                                                      const Input& input,
+                                                      const ConversionRequest& request)
+    {
+        std::vector<ConversionOutput> outputs;
+        auto result = converter.convert(input, [&outputs](std::string_view suggestedName, std::span<const std::byte> data) {
+            outputs.push_back({ std::string(suggestedName), { data.begin(), data.end() } });
+        }, request);
+        return { std::move(result), std::move(outputs) };
+    }
+
+    static ConversionArtifact unsupportedConversion()
+    {
+        ConversionResult result;
+        result.addDiagnostic(MessageSeverity::Error, "No converter is registered for the requested formats.");
+        return { std::move(result), {} };
+    }
+
     std::vector<std::unique_ptr<IConverter>> m_converters;
     std::vector<std::unique_ptr<IMultiOutputConverter>> m_multiOutputConverters;
     std::vector<std::unique_ptr<IReaderConverter>> m_readerConverters;

--- a/include/denigma/conversion.h
+++ b/include/denigma/conversion.h
@@ -418,9 +418,7 @@ private:
             std::memcpy(data.data(), text.data(), text.size());
         }
         std::vector<ConversionOutput> outputs;
-        if (!data.empty()) {
-            outputs.push_back({ {}, std::move(data) });
-        }
+        outputs.push_back({ {}, std::move(data) });
         return { std::move(result), std::move(outputs) };
     }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4,6 +4,13 @@ if(denigma_BUILD_TESTING)
     # Enable testing in this directory
     enable_testing()
 
+    FetchContent_Declare(
+        googletest
+        URL https://github.com/google/googletest/archive/release-1.12.1.tar.gz
+        DOWNLOAD_EXTRACT_TIMESTAMP TRUE
+    )
+    FetchContent_MakeAvailable(googletest)
+
     function(target_add_denigma_test_warnings target_name)
         if (CMAKE_CXX_COMPILER_ID MATCHES "AppleClang|Clang|GNU")
             # Extra warnings for Clang/AppleClang
@@ -149,14 +156,6 @@ endfunction()
     # Add test dependencies
     add_dependencies(denigma_tests GenerateLicenseXxd)
 
-    # Add Google Test as a dependency
-    FetchContent_Declare(
-        googletest
-        URL https://github.com/google/googletest/archive/release-1.12.1.tar.gz
-        DOWNLOAD_EXTRACT_TIMESTAMP TRUE
-    )
-    FetchContent_MakeAvailable(googletest)
-
     # Link Google Test libraries
     target_link_libraries(denigma_tests PRIVATE gmock gtest_main)
 
@@ -169,5 +168,12 @@ endfunction()
             ENVIRONMENT "GTEST_COLOR=1"
         EXTRA_ARGS --gtest_color=yes
     )
+
+    add_executable(denigma_conversion_contract_tests
+        test_conversion_result.cpp
+        ${CMAKE_SOURCE_DIR}/src/io/random_access_reader.cpp
+    )
+    target_add_denigma_test_warnings(denigma_conversion_contract_tests)
+    target_link_libraries(denigma_conversion_contract_tests PRIVATE denigma::conversion gtest_main)
 
 endif()

--- a/tests/test_conversion_result.cpp
+++ b/tests/test_conversion_result.cpp
@@ -67,6 +67,20 @@ public:
     }
 };
 
+class EmptyMemoryConverter final : public denigma::IConverter
+{
+public:
+    [[nodiscard]] denigma::FormatId sourceFormat() const override { return denigma::FormatId::EnigmaXml; }
+    [[nodiscard]] denigma::FormatId targetFormat() const override { return denigma::FormatId::Svg; }
+
+    denigma::ConversionResult convert(std::span<const std::byte>,
+                                      std::ostream&,
+                                      const denigma::ConversionRequest&) const override
+    {
+        return {};
+    }
+};
+
 std::string outputText(const denigma::ConversionOutput& output)
 {
     return { reinterpret_cast<const char*>(output.data.data()), output.data.size() };
@@ -130,6 +144,21 @@ TEST(ConverterRegistry, CollectsNamedReaderMultiOutputs)
     EXPECT_EQ(outputText(artifact.outputs()[0]), "score");
     EXPECT_EQ(artifact.outputs()[1].suggestedName, "part.musicxml");
     EXPECT_EQ(outputText(artifact.outputs()[1]), "part");
+}
+
+TEST(ConverterRegistry, PreservesEmptySingleOutput)
+{
+    denigma::ConverterRegistry registry;
+    registry.add(std::make_unique<EmptyMemoryConverter>());
+    const std::byte input{};
+
+    const auto artifact = registry.convert(denigma::FormatId::EnigmaXml,
+                                           denigma::FormatId::Svg,
+                                           std::span(&input, 1));
+
+    EXPECT_TRUE(artifact);
+    ASSERT_EQ(artifact.outputs().size(), 1u);
+    EXPECT_TRUE(artifact.outputs().front().data.empty());
 }
 
 TEST(ConverterRegistry, ReportsUnsupportedConversion)

--- a/tests/test_conversion_result.cpp
+++ b/tests/test_conversion_result.cpp
@@ -19,11 +19,60 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+#include <cstddef>
+#include <memory>
+#include <ostream>
+#include <span>
 #include <string>
+#include <string_view>
 
 #include "gtest/gtest.h"
 
 #include "denigma/conversion.h"
+
+namespace {
+
+class MemoryConverter final : public denigma::IConverter
+{
+public:
+    [[nodiscard]] denigma::FormatId sourceFormat() const override { return denigma::FormatId::EnigmaXml; }
+    [[nodiscard]] denigma::FormatId targetFormat() const override { return denigma::FormatId::MnxJson; }
+
+    denigma::ConversionResult convert(std::span<const std::byte>,
+                                      std::ostream& output,
+                                      const denigma::ConversionRequest&) const override
+    {
+        output << "mnx";
+        denigma::ConversionResult result;
+        result.addDiagnostic(denigma::MessageSeverity::Warning, "preserved warning");
+        return result;
+    }
+};
+
+class ReaderMultiOutputConverter final : public denigma::IReaderMultiOutputConverter
+{
+public:
+    [[nodiscard]] denigma::FormatId sourceFormat() const override { return denigma::FormatId::Musx; }
+    [[nodiscard]] denigma::FormatId targetFormat() const override { return denigma::FormatId::MusicXml; }
+
+    denigma::ConversionResult convert(const denigma::IRandomAccessReader&,
+                                      const denigma::MultiOutputCallback& outputCallback,
+                                      const denigma::ConversionRequest&) const override
+    {
+        const std::string score = "score";
+        const std::string part = "part";
+        outputCallback("score.musicxml", std::as_bytes(std::span(score)));
+        outputCallback("part.musicxml", std::as_bytes(std::span(part)));
+        return {};
+    }
+};
+
+std::string outputText(const denigma::ConversionOutput& output)
+{
+    return { reinterpret_cast<const char*>(output.data.data()), output.data.size() };
+}
+
+} // namespace
 
 TEST(ConversionResult, TracksDiagnosticsAndErrorState)
 {
@@ -46,4 +95,55 @@ TEST(ConversionResult, TracksDiagnosticsAndErrorState)
     ASSERT_EQ(result.diagnostics().size(), 2u);
     EXPECT_EQ(result.diagnostics().back().severity, denigma::MessageSeverity::Error);
     EXPECT_EQ(result.diagnostics().back().message, "error");
+}
+
+TEST(ConverterRegistry, CollectsOwnedSingleOutputAndDiagnostics)
+{
+    denigma::ConverterRegistry registry;
+    registry.add(std::make_unique<MemoryConverter>());
+    const std::byte input{};
+
+    const auto artifact = registry.convert(denigma::FormatId::EnigmaXml,
+                                           denigma::FormatId::MnxJson,
+                                           std::span(&input, 1));
+
+    EXPECT_TRUE(artifact);
+    ASSERT_EQ(artifact.outputs().size(), 1u);
+    EXPECT_TRUE(artifact.outputs().front().suggestedName.empty());
+    EXPECT_EQ(outputText(artifact.outputs().front()), "mnx");
+    ASSERT_EQ(artifact.result().diagnostics().size(), 1u);
+    EXPECT_EQ(artifact.result().diagnostics().front().message, "preserved warning");
+}
+
+TEST(ConverterRegistry, CollectsNamedReaderMultiOutputs)
+{
+    denigma::ConverterRegistry registry;
+    registry.add(std::make_unique<ReaderMultiOutputConverter>());
+    const std::byte input{};
+    denigma::BufferRandomAccessReader reader(std::span(&input, 1));
+
+    const auto artifact = registry.convert(denigma::FormatId::Musx, denigma::FormatId::MusicXml, reader);
+
+    EXPECT_TRUE(artifact);
+    ASSERT_EQ(artifact.outputs().size(), 2u);
+    EXPECT_EQ(artifact.outputs()[0].suggestedName, "score.musicxml");
+    EXPECT_EQ(outputText(artifact.outputs()[0]), "score");
+    EXPECT_EQ(artifact.outputs()[1].suggestedName, "part.musicxml");
+    EXPECT_EQ(outputText(artifact.outputs()[1]), "part");
+}
+
+TEST(ConverterRegistry, ReportsUnsupportedConversion)
+{
+    const denigma::ConverterRegistry registry;
+    const std::byte input{};
+
+    const auto artifact = registry.convert(denigma::FormatId::EnigmaXml,
+                                           denigma::FormatId::Svg,
+                                           std::span(&input, 1));
+
+    EXPECT_FALSE(artifact);
+    EXPECT_TRUE(artifact.hasError());
+    EXPECT_TRUE(artifact.outputs().empty());
+    ASSERT_EQ(artifact.result().diagnostics().size(), 1u);
+    EXPECT_EQ(artifact.result().diagnostics().front().severity, denigma::MessageSeverity::Error);
 }


### PR DESCRIPTION
## Summary

- default CLI and test products on only when Denigma is the top-level CMake project
- add a public `ConversionArtifact` that owns generated documents and converter result metadata
- add high-level `ConverterRegistry::convert` overloads for memory and random-access inputs
- preserve suggested filenames from multi-output converters
- document source-based `FetchContent` consumption and runtime format dispatch
- add a focused downstream API contract-test target

## Motivation

External consumers need both clean CMake targets and a supported API that does not require them to duplicate Denigma's four converter interface shapes. The new artifact API normalizes single-output, multi-output, memory-backed, and reader-backed converters while preserving typed format options and the existing low-level interfaces.

This also provides one additive result boundary for future structured gap reports: downstream consumers can keep reading outputs and diagnostics while Denigma extends `ConversionResult` with gap metadata later.

## External consumer result

[Viritura/Viritura#64](https://github.com/Viritura/Viritura/pull/64) pins this branch at `286112c438f303f03845356a61093487e3583f78`. Its Emscripten project:

- adds Denigma as a subproject without enabling the CLI
- registers and links only `denigma::mnx`
- converts through `ConverterRegistry::convert`
- uses Denigma's owned `ConversionArtifact` instead of a downstream result container
- builds at the C++20 minimum with Emscripten 5.0.7
- passes an actual MUSX-to-MNX conversion smoke test and 16 focused importer/editor tests

## Validation

- built `denigma::mnx` successfully with Emscripten 5.0.7 at C++20
- built and ran `denigma_conversion_contract_tests` under Emscripten: 4 tests passed
- rebuilt and smoke-tested the Viritura WASM importer against the exact fork commit

The existing aggregate Emscripten `denigma_tests` target currently fails in unrelated `textmetrics.cpp` warnings-as-errors; the focused contract target avoids that unrelated production graph.
