### PR TITLE
Update repository references for openmusx organization

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -5,7 +5,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thank you for helping improve denigma. Please reduce the problem to the smallest reproducible example you can share. If this is a request for MusicXML support that denigma does not yet implement, use the [MusicXML feature gap form](https://github.com/rpatters1/denigma/issues/new?template=musicxml-gap.yml) instead.
+        Thank you for helping improve denigma. Please reduce the problem to the smallest reproducible example you can share. If this is a request for MusicXML support that denigma does not yet implement, use the [MusicXML feature gap form](https://github.com/openmusx/denigma/issues/new?template=musicxml-gap.yml) instead.
 
   - type: textarea
     id: summary
@@ -97,7 +97,7 @@ body:
     id: prior-search
     attributes:
       label: Prior search
-      description: Confirm that this bug is not already tracked in [open or closed GitHub issues](https://github.com/rpatters1/denigma/issues?q=is%3Aissue).
+      description: Confirm that this bug is not already tracked in [open or closed GitHub issues](https://github.com/openmusx/denigma/issues?q=is%3Aissue).
       options:
         - label: I searched both open and closed issues for this bug.
           required: true
@@ -106,7 +106,7 @@ body:
     id: sharing
     attributes:
       label: Permission to use attachments for testing
-      description: Public issue attachments can be viewed and downloaded by anyone. Test fixtures committed to denigma are distributed under the repository's [MIT License](https://github.com/rpatters1/denigma/blob/main/LICENSE).
+      description: Public issue attachments can be viewed and downloaded by anyone. Test fixtures committed to denigma are distributed under the repository's [MIT License](https://github.com/openmusx/denigma/blob/main/LICENSE).
       options:
         - label: If I attached example files, I own them or have authority to grant permission, and they contain no private or sensitive information.
           required: true

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -5,7 +5,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thank you for suggesting an improvement. Describe the need independently of a particular implementation so that alternatives remain open. For missing MusicXML support, use the [MusicXML feature gap form](https://github.com/rpatters1/denigma/issues/new?template=musicxml-gap.yml) instead.
+        Thank you for suggesting an improvement. Describe the need independently of a particular implementation so that alternatives remain open. For missing MusicXML support, use the [MusicXML feature gap form](https://github.com/openmusx/denigma/issues/new?template=musicxml-gap.yml) instead.
 
   - type: textarea
     id: problem
@@ -57,7 +57,7 @@ body:
     id: prior-search
     attributes:
       label: Prior search
-      description: Confirm that this feature is not already tracked in [open or closed GitHub issues](https://github.com/rpatters1/denigma/issues?q=is%3Aissue).
+      description: Confirm that this feature is not already tracked in [open or closed GitHub issues](https://github.com/openmusx/denigma/issues?q=is%3Aissue).
       options:
         - label: I searched both open and closed issues for this feature.
           required: true
@@ -66,7 +66,7 @@ body:
     id: sharing
     attributes:
       label: Permission to use attachments for testing
-      description: Public issue attachments can be viewed and downloaded by anyone. Test fixtures committed to denigma are distributed under the repository's [MIT License](https://github.com/rpatters1/denigma/blob/main/LICENSE).
+      description: Public issue attachments can be viewed and downloaded by anyone. Test fixtures committed to denigma are distributed under the repository's [MIT License](https://github.com/openmusx/denigma/blob/main/LICENSE).
       options:
         - label: If I attached example files, I own them or have authority to grant permission, and they contain no private or sensitive information.
           required: true

--- a/.github/ISSUE_TEMPLATE/musicxml-gap.yml
+++ b/.github/ISSUE_TEMPLATE/musicxml-gap.yml
@@ -82,7 +82,7 @@ body:
     id: prior-search
     attributes:
       label: Prior search
-      description: Confirm that this request is not already tracked in the [MusicXML feature roadmap](https://github.com/rpatters1/denigma/blob/main/src/formats/musicxml/roadmap.md) or [GitHub issues](https://github.com/rpatters1/denigma/issues?q=is%3Aissue).
+      description: Confirm that this request is not already tracked in the [MusicXML feature roadmap](https://github.com/openmusx/denigma/blob/main/src/formats/musicxml/roadmap.md) or [GitHub issues](https://github.com/openmusx/denigma/issues?q=is%3Aissue).
       options:
         - label: I searched the roadmap and both open and closed issues for this feature.
           required: true
@@ -91,7 +91,7 @@ body:
     id: sharing
     attributes:
       label: Permission to use attachments for testing
-      description: Public issue attachments can be viewed and downloaded by anyone. Test fixtures committed to denigma are distributed under the repository's [MIT License](https://github.com/rpatters1/denigma/blob/main/LICENSE).
+      description: Public issue attachments can be viewed and downloaded by anyone. Test fixtures committed to denigma are distributed under the repository's [MIT License](https://github.com/openmusx/denigma/blob/main/LICENSE).
       options:
         - label: I own the attached MUSX and MusicXML examples, or I have authority to grant the permissions below, and the files contain no private or sensitive information.
           required: true

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -223,7 +223,7 @@ set(musx_BUILD_TESTING OFF CACHE BOOL "Do not build tests for musx")
 # Fetch musx
 FetchContent_Declare(
     musx
-    GIT_REPOSITORY https://github.com/rpatters1/musxdom.git
+    GIT_REPOSITORY https://github.com/openmusx/musxdom.git
     GIT_TAG        ${MUSXDOM_GIT_TAG_OR_BRANCH}
     DOWNLOAD_EXTRACT_TIMESTAMP TRUE
 )
@@ -254,7 +254,7 @@ set(smufl_mapping_BUILD_TESTING OFF CACHE BOOL "Do not build tests for smufl_map
 # Fetch musx
 FetchContent_Declare(
     smufl_mapping
-    GIT_REPOSITORY https://github.com/rpatters1/smufl-mapping.git
+    GIT_REPOSITORY https://github.com/openmusx/smufl-mapping.git
     GIT_TAG        ${SMUFL_MAPPING_GIT_TAG_OR_BRANCH}
     DOWNLOAD_EXTRACT_TIMESTAMP TRUE
 )

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Denigma is split into small reusable libraries as well as the CLI utility:
 - `denigma_format_musicxml` converts MUSX content to MusicXML.
 - `denigma_format_svg` converts MUSX content to SVG.
 
-The documentation site for the library API is [https://rpatters1.github.io/denigma/](https://rpatters1.github.io/denigma/).
+The documentation site for the library API is [https://openmusx.github.io/denigma/](https://openmusx.github.io/denigma/).
 
 ## Linking
 
@@ -58,7 +58,7 @@ auto artifact = registry.convert(
 
 `ConversionArtifact` owns the generated documents in emission order and preserves the converter's `ConversionResult`. Multi-output converters retain each suggested filename. The format-specific typed converters and their `convert` overloads remain a first-class alternative.
 
-The companion [denigma-examples](https://github.com/rpatters1/denigma-examples) repository demonstrates this from separate native and WebAssembly projects using CMake `FetchContent` or a local Denigma checkout.
+The companion [denigma-examples](https://github.com/openmusx/denigma-examples) repository demonstrates this from separate native and WebAssembly projects using CMake `FetchContent` or a local Denigma checkout.
 
 When Denigma is added as a CMake subproject, its CLI and tests are disabled by default. Consumers can override either option before making Denigma available:
 
@@ -69,7 +69,7 @@ set(denigma_BUILD_TESTING OFF CACHE BOOL "" FORCE)
 include(FetchContent)
 FetchContent_Declare(
 	denigma
-	GIT_REPOSITORY https://github.com/rpatters1/denigma.git
+	GIT_REPOSITORY https://github.com/openmusx/denigma.git
 	GIT_TAG        <release-tag-or-commit>
 )
 FetchContent_MakeAvailable(denigma)


### PR DESCRIPTION
Follow-up to the transfer of this repository (and its dependencies) to the `openmusx` GitHub organization.

- FetchContent `GIT_REPOSITORY` for musxdom and smufl-mapping → `openmusx` (pins unchanged)
- README: docs site → `openmusx.github.io/denigma`; denigma-examples link and FetchContent example → `openmusx`
- Issue templates: links to issues, LICENSE, and the MusicXML roadmap → `openmusx/denigma`

Not changed: `src/formats/mnx/CMakeLists.txt` still references `rpatters1/mnxdom`, which has not been transferred yet.

Verified locally with a fresh build fetching musxdom and smufl-mapping from `openmusx`; 461/461 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018w3X7hGhogbnLVtL6XNuhK