### PR TITLE
Build the WebAssembly module in Denigma

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,9 +11,15 @@ on:
   pull_request:
     branches:
       - main
+  release:
+    types:
+      - published
 
 jobs:
   build:
+    # Native release binaries are packaged by hand; a published release only
+    # needs the WebAssembly job.
+    if: github.event_name != 'release'
     runs-on: ${{ matrix.os }}
 
     strategy:
@@ -30,7 +36,7 @@ jobs:
     steps:
       # Checkout the repository with submodules
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: true  # Clone submodules recursively
           fetch-depth: 0    # Ensure full history for submodules
@@ -70,3 +76,63 @@ jobs:
       # Run Tests
       - name: Run Tests
         run: ctest --test-dir build/tests --output-on-failure
+
+  wasm:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # attaches the module to published releases
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          submodules: true
+          fetch-depth: 0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Set up Emscripten
+        uses: emscripten-core/setup-emsdk@v16
+        with:
+          version: 5.0.7
+          actions-cache-folder: emsdk-cache
+
+      - name: Install Ninja
+        run: sudo apt-get update && sudo apt-get install -y ninja-build
+
+      - name: Configure with CMake
+        run: emcmake cmake -G Ninja -S . -B build-wasm -DCMAKE_BUILD_TYPE=MinSizeRel -DDENIGMA_CXX_STANDARD=20
+
+      # Build only the module so the text-measuring converters, which the module
+      # does not export, stay out of the WebAssembly build.
+      - name: Build WebAssembly module
+        run: cmake --build build-wasm --target denigma_wasm --parallel 2
+
+      - name: Run WebAssembly smoke test
+        run: node tests/wasm/smoke.mjs build-wasm/wasm/denigma.js build-wasm/wasm/denigma.wasm
+
+      # A pull request only needs to prove the module builds; the artifact is
+      # for main, where consumers pin.
+      - name: Upload WebAssembly module
+        if: github.event_name != 'pull_request'
+        uses: actions/upload-artifact@v6
+        with:
+          name: denigma-wasm
+          path: |
+            build-wasm/wasm/denigma.js
+            build-wasm/wasm/denigma.wasm
+          if-no-files-found: error
+
+      # A published release carries the module as a build product alongside the
+      # native binaries, named like them: denigma.<tag>.wasm.zip.
+      - name: Attach module to the release
+        if: github.event_name == 'release'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          (cd build-wasm/wasm && zip "../../denigma.${TAG}.wasm.zip" denigma.js denigma.wasm)
+          gh release upload "${TAG}" "denigma.${TAG}.wasm.zip" --clobber

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: true
           fetch-depth: 0
@@ -36,10 +36,10 @@ jobs:
         run: cmake --build build --target denigma_docs
 
       - name: Configure Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: build/docs/api/html
 
@@ -53,4 +53,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,4 @@ tests/data/*
 # Explicitly exclude unwanted files in tests/data/inputs
 tests/data/inputs/**/.DS_Store
 
+/build-wasm/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,7 @@ The repository builds a CLI plus reusable libraries for classification, massage,
 - `src/massage` contains MusicXML transformation helpers.
 - `src/export` contains export-related code shared by tests and production targets.
 - `src/io` and `src/utils` contain lower-level helpers.
+- `src/wasm` contains the WebAssembly C ABI wrapper built by the `denigma_wasm` target.
 - `tests` contains the GoogleTest suite and fixture data.
 - `tests/data/inputs` contains checked-in input fixtures.
 - `tests/data/inputs/reference` contains checked-in expected-output fixtures.
@@ -50,6 +51,12 @@ The repository builds a CLI plus reusable libraries for classification, massage,
   - `./build.cmake -- clean`
 - The build downloads third-party dependencies through `FetchContent`, including `pugixml`, `nlohmann_json`, `zlib`, and `googletest`.
 - If you need a local MUSX DOM checkout, set `MUSX_LOCAL_PATH` in CMake rather than editing dependency logic.
+- The WebAssembly module (`src/wasm`, target `denigma_wasm`, option `denigma_BUILD_WASM`) is built with Emscripten:
+  - `emcmake cmake -S . -B build-wasm -DCMAKE_BUILD_TYPE=MinSizeRel -DDENIGMA_CXX_STANDARD=20`
+  - `cmake --build build-wasm --target denigma_wasm`
+  - `node tests/wasm/smoke.mjs build-wasm/wasm/denigma.js build-wasm/wasm/denigma.wasm`
+- Always name the `denigma_wasm` target for that build. The `all` target also compiles the text-measuring converters and `denigma_textmetrics`, which the module does not link and which do not compile under Emscripten.
+- The exported function list in `src/wasm/CMakeLists.txt` and the C ABI in `src/wasm/denigma_wasm.cpp` are the contract with `denigma-online` and `viritura`, which consume the module built from a pinned Denigma commit. Changing either changes those consumers.
 
 ## Test Rules
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -182,6 +182,12 @@ if(TARGET zlib)
         EXCLUDE_FROM_ALL TRUE
         EXCLUDE_FROM_DEFAULT_BUILD TRUE
     )
+    if(EMSCRIPTEN)
+        # Without shared library support the SHARED target becomes a static
+        # library named libz.a, the same file zlibstatic produces. Ninja refuses
+        # two rules for one output even though the target is never built.
+        set_target_properties(zlib PROPERTIES OUTPUT_NAME z_shared)
+    endif()
 endif()
 
 if(TARGET zlibstatic)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,8 +4,20 @@ cmake_minimum_required(VERSION 3.22)
 # Project name and version
 project(denigma VERSION 4.0.0)
 
-option(denigma_BUILD_CLI "Build the Denigma command-line application" ${PROJECT_IS_TOP_LEVEL})
-option(denigma_BUILD_TESTING "Build the Denigma test suite" ${PROJECT_IS_TOP_LEVEL})
+# Under Emscripten the natural products are the WebAssembly module and nothing
+# that has to run on the host, so the defaults flip accordingly.
+if(EMSCRIPTEN)
+    set(_denigma_default_native OFF)
+    set(_denigma_default_wasm ${PROJECT_IS_TOP_LEVEL})
+else()
+    set(_denigma_default_native ${PROJECT_IS_TOP_LEVEL})
+    set(_denigma_default_wasm OFF)
+endif()
+option(denigma_BUILD_CLI "Build the Denigma command-line application" ${_denigma_default_native})
+option(denigma_BUILD_TESTING "Build the Denigma test suite" ${_denigma_default_native})
+option(denigma_BUILD_WASM "Build the Denigma WebAssembly module (requires Emscripten)" ${_denigma_default_wasm})
+unset(_denigma_default_native)
+unset(_denigma_default_wasm)
 
 # Specify C++ standard and minimum macOS version
 set(DENIGMA_CXX_STANDARD "23" CACHE STRING "C++ standard used to build Denigma; must be at least 20")
@@ -19,6 +31,13 @@ endif()
 set(CMAKE_CXX_STANDARD ${DENIGMA_CXX_STANDARD})
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
+
+if(EMSCRIPTEN)
+    # Emscripten disables exceptions unless asked at both compile and link time.
+    # The language flags reach every compile and compiler-driver link, including
+    # the FetchContent dependencies, which is what makes throwing safe throughout.
+    string(APPEND CMAKE_CXX_FLAGS " -fexceptions")
+endif()
 
 # Prevent in-source builds
 if(PROJECT_SOURCE_DIR STREQUAL PROJECT_BINARY_DIR)
@@ -375,6 +394,10 @@ if(denigma_BUILD_CLI)
             VERBATIM
         )
     endif()
+endif()
+
+if(denigma_BUILD_WASM)
+    add_subdirectory(src/wasm)
 endif()
 
 if(denigma_BUILD_TESTING)

--- a/README.md
+++ b/README.md
@@ -141,6 +141,18 @@ or (for Linux or macOS)
 ./build.cmake -- clean
 ```
 
+## WebAssembly build
+
+Denigma also builds a WebAssembly module exposing MUSX inspection and conversion to EnigmaXML, MusicXML, and MNX through a small C ABI (`src/wasm/denigma_wasm.cpp`). It is the module that [denigma-online](https://github.com/openmusx/denigma-online) runs in the browser. Building it requires [Emscripten](https://emscripten.org/) (CI uses 5.0.7):
+
+```bash
+emcmake cmake -S . -B build-wasm -DCMAKE_BUILD_TYPE=MinSizeRel -DDENIGMA_CXX_STANDARD=20
+cmake --build build-wasm --target denigma_wasm
+node tests/wasm/smoke.mjs build-wasm/wasm/denigma.js build-wasm/wasm/denigma.wasm
+```
+
+Build the `denigma_wasm` target rather than `all`: the module links only the EnigmaXML, MusicXML, and MNX converters, and naming the target keeps the text-measuring converters (SVG and MSS) and their font dependencies out of the build. Under Emscripten the CLI and tests are off by default and `denigma_BUILD_WASM` is on. The module lands in `build-wasm/wasm/` as `denigma.js` and `denigma.wasm`; CI builds and smoke-tests the module on every pull request, uploads the pair as the `denigma-wasm` artifact of every push to `main`, and attaches it to every published release as `denigma.<tag>.wasm.zip` alongside the native binaries.
+
 ## Visual Studio Code setup
 
 See [`.vscode_template/README.md`](.vscode_template/README.md) for OS-specific templates (`macos`, `linux`, `windows`) with `launch.json` and `tasks.json`.

--- a/src/wasm/CMakeLists.txt
+++ b/src/wasm/CMakeLists.txt
@@ -1,0 +1,78 @@
+# WebAssembly module exposing the MUSX inspection and conversion entry points
+# through a small C ABI. Denigma Online consumes the denigma.js/denigma.wasm pair
+# this target emits, so the exported function list below is that site's contract.
+
+if(NOT EMSCRIPTEN)
+    message(FATAL_ERROR "denigma_BUILD_WASM requires the Emscripten toolchain (configure with emcmake).")
+endif()
+
+add_executable(denigma_wasm denigma_wasm.cpp)
+target_compile_options(denigma_wasm PRIVATE ${DENIGMA_WARNING_OPTIONS})
+target_link_libraries(denigma_wasm PRIVATE
+    denigma::enigmaxml
+    denigma::mnx
+    denigma::musicxml
+    denigma_internal_deps
+)
+
+set(DENIGMA_WASM_OUTPUT_DIR "${PROJECT_BINARY_DIR}/wasm")
+set_target_properties(denigma_wasm PROPERTIES
+    OUTPUT_NAME denigma
+    SUFFIX ".js"
+    RUNTIME_OUTPUT_DIRECTORY "${DENIGMA_WASM_OUTPUT_DIR}"
+)
+
+set(_denigma_wasm_exports
+    _denigma_malloc
+    _denigma_free
+    _denigma_inspect
+    _denigma_convert
+    _denigma_result_destroy
+    _denigma_result_success
+    _denigma_result_diagnostic_count
+    _denigma_result_diagnostic_severity
+    _denigma_result_diagnostic_message
+    _denigma_result_score_name
+    _denigma_result_score_page_width_mm
+    _denigma_result_score_page_height_mm
+    _denigma_result_score_spatium_mm
+    _denigma_result_score_has_page_margins
+    _denigma_result_score_page_margin_top_sp
+    _denigma_result_score_page_margin_bottom_sp
+    _denigma_result_score_page_margin_left_sp
+    _denigma_result_score_page_margin_right_sp
+    _denigma_result_part_count
+    _denigma_result_part_id
+    _denigma_result_part_name
+    _denigma_result_part_output_index
+    _denigma_result_part_page_width_mm
+    _denigma_result_part_page_height_mm
+    _denigma_result_part_spatium_mm
+    _denigma_result_part_has_page_margins
+    _denigma_result_part_page_margin_top_sp
+    _denigma_result_part_page_margin_bottom_sp
+    _denigma_result_part_page_margin_left_sp
+    _denigma_result_part_page_margin_right_sp
+    _denigma_result_output_count
+    _denigma_result_output_name
+    _denigma_result_output_data
+    _denigma_result_output_size
+    _denigma_result_output_index
+    _denigma_version
+    _denigma_commit
+)
+list(JOIN _denigma_wasm_exports "," _denigma_wasm_exports)
+
+target_compile_options(denigma_wasm PRIVATE -Oz)
+target_link_options(denigma_wasm PRIVATE
+    -Oz
+    "-sMODULARIZE=1"
+    "-sEXPORT_ES6=1"
+    "-sENVIRONMENT=web,worker,node"
+    "-sALLOW_MEMORY_GROWTH=1"
+    "-sFILESYSTEM=0"
+    "-sASSERTIONS=0"
+    "-sEXPORTED_FUNCTIONS=${_denigma_wasm_exports}"
+    "-sEXPORTED_RUNTIME_METHODS=HEAPU8,UTF8ToString"
+)
+unset(_denigma_wasm_exports)

--- a/src/wasm/denigma_wasm.cpp
+++ b/src/wasm/denigma_wasm.cpp
@@ -1,0 +1,640 @@
+// Copyright 2026 Robert G. Patterson.
+// SPDX-License-Identifier: MIT
+
+#include <algorithm>
+#include <cctype>
+#include <cstddef>
+#include <cstdint>
+#include <exception>
+#include <iterator>
+#include <memory>
+#include <new>
+#include <optional>
+#include <ostream>
+#include <set>
+#include <span>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include "denigma/io/random_access_reader.h"
+#include "core/denigma.h"
+#include "core/musx_reader.h"
+#include "formats/enigmaxml/enigmaxml.h"
+#include "utils/ziputils.h"
+
+// The public converter adapters extract the MUSX archive on every call. These are
+// the entry points behind those adapters, so a single extraction can serve an
+// inspection and every conversion that follows. They are declared in
+// formats/musicxml/musicxml.h and formats/mnx/mnx.h, but those headers pull in mx
+// and mnxdom, which are private dependencies of the libraries this target links.
+// Declaring them here keeps the wrapper's build off that graph; a signature change
+// in either exporter surfaces as a link error.
+namespace denigma::formats::musicxml::detail {
+void convert(const CommandInputData& inputData,
+             const DenigmaContext& denigmaContext,
+             const MultiOutputCallback& outputCallback);
+} // namespace denigma::formats::musicxml::detail
+
+namespace denigma::formats::mnx::detail {
+void exportJson(std::ostream& output, const CommandInputData& inputData, const DenigmaContext& denigmaContext);
+} // namespace denigma::formats::mnx::detail
+
+namespace {
+
+struct OutputFile
+{
+    std::string name;
+    std::vector<std::uint8_t> data;
+    int sourceIndex{ -1 };
+};
+
+struct PageSize
+{
+    double widthMm{};
+    double heightMm{};
+    double spatiumMm{};
+    bool hasMargins{};
+    double marginTopSp{};
+    double marginBottomSp{};
+    double marginLeftSp{};
+    double marginRightSp{};
+};
+
+struct PartInfo
+{
+    int id{};
+    std::string name;
+    int outputIndex{};
+    int partOrder{};
+    PageSize pageSize;
+};
+
+struct OnlineResult
+{
+    bool success{ true };
+    std::string scoreName{ "Score" };
+    PageSize scorePageSize;
+    std::vector<denigma::Diagnostic> diagnostics;
+    std::vector<PartInfo> parts;
+    std::vector<OutputFile> outputs;
+};
+
+enum class InputFormat
+{
+    Musx,
+    EnigmaXml,
+    ZippedEnigmaXml
+};
+
+bool endsWithCaseInsensitive(std::string_view value, std::string_view suffix)
+{
+    if (value.size() < suffix.size()) return false;
+    return std::equal(suffix.rbegin(), suffix.rend(), value.rbegin(), [](char lhs, char rhs) {
+        return std::tolower(static_cast<unsigned char>(lhs)) == std::tolower(static_cast<unsigned char>(rhs));
+    });
+}
+
+InputFormat inputFormat(const char* sourceName)
+{
+    const std::string_view name = sourceName ? sourceName : "browser.musx";
+    if (endsWithCaseInsensitive(name, ".enigmaxml.zip")) return InputFormat::ZippedEnigmaXml;
+    if (endsWithCaseInsensitive(name, ".enigmaxml")) return InputFormat::EnigmaXml;
+    if (endsWithCaseInsensitive(name, ".musx")) return InputFormat::Musx;
+    throw std::invalid_argument("Unsupported input filename.");
+}
+
+void addDiagnostic(OnlineResult& result, denigma::MessageSeverity severity, std::string message)
+{
+    result.success = result.success && severity != denigma::MessageSeverity::Error;
+    result.diagnostics.push_back({ severity, std::move(message) });
+}
+
+const char* fallbackSourceName(InputFormat format)
+{
+    return format == InputFormat::Musx ? "browser.musx" : "browser.enigmaxml";
+}
+
+denigma::DenigmaContext makeInputContext(OnlineResult& result, const char* sourceName, const char* fallbackName)
+{
+    denigma::DenigmaContext context(DENIGMA_NAME);
+    context.inputFilePath = sourceName ? sourceName : fallbackName;
+    context.verbose = true;
+    context.logCallback = [&result](denigma::MessageSeverity severity, std::string_view message) {
+        addDiagnostic(result, severity, std::string(message));
+    };
+    return context;
+}
+
+// Mirrors makeMusicXmlContext()/makeMnxContext() in Denigma's converter adapters
+// (src/formats/*/*_converter.cpp). Those adapters re-extract the archive on every
+// call, so this wrapper drives the detail entry points with cached input data and
+// assembles the equivalent context here. Validation stays on and quiet stays off,
+// matching the CommonOptions defaults the adapters map from.
+denigma::DenigmaContext makeConversionContext(OnlineResult& result,
+                                              const char* sourceName,
+                                              InputFormat format,
+                                              denigma::ConversionResult& conversionResult)
+{
+    auto context = makeInputContext(result, sourceName, fallbackSourceName(format));
+    context.conversionResult = &conversionResult;
+    return context;
+}
+
+std::span<const std::byte> inputBytes(const std::uint8_t* data, std::size_t size)
+{
+    if (!data && size != 0) {
+        throw std::invalid_argument("Input buffer is null.");
+    }
+    return { reinterpret_cast<const std::byte*>(data), size };
+}
+
+denigma::Buffer copyBytes(std::span<const std::byte> bytes)
+{
+    denigma::Buffer result;
+    result.reserve(bytes.size());
+    std::transform(bytes.begin(), bytes.end(), std::back_inserter(result), [](std::byte value) {
+        return static_cast<char>(value);
+    });
+    return result;
+}
+
+denigma::CommandInputData readInputData(std::span<const std::byte> bytes,
+                                        InputFormat format,
+                                        const denigma::DenigmaContext& context)
+{
+    if (format == InputFormat::Musx) {
+        denigma::BufferRandomAccessReader reader(bytes);
+        return denigma::formats::enigmaxml::detail::extractMusxInputData(reader, context);
+    }
+    if (format == InputFormat::ZippedEnigmaXml) {
+        denigma::BufferRandomAccessReader reader(bytes);
+        const auto xml = utils::readSoleFileWithExtension(reader, ENIGMAXML_EXTENSION, context);
+        return { denigma::Buffer(xml.begin(), xml.end()), std::nullopt, {} };
+    }
+    return { copyBytes(bytes), std::nullopt, {} };
+}
+
+// Extracting a MUSX archive inflates the zip and deobfuscates the EnigmaXML inside
+// it. The browser works the same file over and over -- one inspection, then a
+// conversion for every format change, part selection, and retry -- so hold the
+// extracted data and reuse it until a different file arrives.
+struct InputCache
+{
+    std::string sourceName;
+    std::size_t size{};
+    std::uint64_t hash{};
+    denigma::CommandInputData data;
+    bool valid{};
+};
+
+InputCache inputCache;
+
+std::uint64_t contentHash(std::span<const std::byte> bytes)
+{
+    std::uint64_t hash = 14695981039346656037ull; // FNV-1a
+    for (const std::byte value : bytes) {
+        hash ^= static_cast<std::uint64_t>(value);
+        hash *= 1099511628211ull;
+    }
+    return hash;
+}
+
+const denigma::CommandInputData& cachedInputData(std::span<const std::byte> bytes,
+                                                 InputFormat format,
+                                                 const denigma::DenigmaContext& context,
+                                                 const char* sourceName)
+{
+    const std::string name = sourceName ? sourceName : "";
+    const auto hash = contentHash(bytes);
+    if (inputCache.valid && inputCache.size == bytes.size() && inputCache.hash == hash
+        && inputCache.sourceName == name) {
+        return inputCache.data;
+    }
+    inputCache = {}; // release the previous extraction before allocating the next one
+    inputCache.data = readInputData(bytes, format, context);
+    inputCache.sourceName = name;
+    inputCache.size = bytes.size();
+    inputCache.hash = hash;
+    inputCache.valid = true;
+    return inputCache.data;
+}
+
+std::span<const std::byte> primaryBytes(const denigma::CommandInputData& input)
+{
+    return { reinterpret_cast<const std::byte*>(input.primaryBuffer.data()), input.primaryBuffer.size() };
+}
+
+void appendOutput(OnlineResult& result, std::string_view name, std::span<const std::byte> data, int sourceIndex = -1)
+{
+    OutputFile output;
+    output.name = name;
+    output.sourceIndex = sourceIndex;
+    output.data.resize(data.size());
+    std::transform(data.begin(), data.end(), output.data.begin(), [](std::byte value) {
+        return static_cast<std::uint8_t>(value);
+    });
+    result.outputs.push_back(std::move(output));
+}
+
+void appendOutput(OnlineResult& result, std::string name, const std::string& data)
+{
+    OutputFile output;
+    output.name = std::move(name);
+    output.data.assign(data.begin(), data.end());
+    result.outputs.push_back(std::move(output));
+}
+
+PageSize pageSizeForPart(const musx::dom::DocumentPtr& document, musx::dom::Cmper partId)
+{
+    try {
+        const auto options = document->getOptions()->get<musx::dom::options::PageFormatOptions>();
+        const auto format = options ? options->calcPageFormatForPart(partId) : nullptr;
+        if (!format || format->pageWidth <= 0 || format->pageHeight <= 0) return {};
+        PageSize result{
+            static_cast<double>(format->pageWidth) / musx::dom::EVPU_PER_MM,
+            static_cast<double>(format->pageHeight) / musx::dom::EVPU_PER_MM,
+            format->calcCombinedSystemScaling().toDouble() * musx::dom::EVPU_PER_SPACE
+                / musx::dom::EVPU_PER_MM
+        };
+        const auto firstPage = document->getOthers()->get<musx::dom::others::Page>(partId, 1);
+        const auto marginScaling = firstPage && !firstPage->holdMargins
+            ? format->calcSystemScaling().toDouble()
+            : format->calcCombinedSystemScaling().toDouble();
+        if (marginScaling <= 0) return result;
+        const auto marginSp = [marginScaling](musx::dom::Evpu value) {
+            return static_cast<double>(value) / (musx::dom::EVPU_PER_SPACE * marginScaling);
+        };
+        result.hasMargins = true;
+        result.marginTopSp = marginSp(-(firstPage ? firstPage->margTop : format->leftPageMarginTop));
+        result.marginBottomSp = marginSp(firstPage ? firstPage->margBottom : format->leftPageMarginBottom);
+        result.marginLeftSp = marginSp(firstPage ? firstPage->margLeft : format->leftPageMarginLeft);
+        result.marginRightSp = marginSp(-(firstPage ? firstPage->margRight : format->leftPageMarginRight));
+        return result;
+    } catch (...) {
+        return {};
+    }
+}
+
+void finishConversion(OnlineResult& result, const denigma::ConversionResult& conversionResult)
+{
+    if (conversionResult.hasError()) {
+        result.success = false;
+    }
+    if (result.outputs.empty() && result.success) {
+        addDiagnostic(result, denigma::MessageSeverity::Error, "Conversion produced no output.");
+    } else if (result.success && std::any_of(result.outputs.begin(), result.outputs.end(), [](const OutputFile& output) {
+        return output.data.empty();
+    })) {
+        addDiagnostic(result, denigma::MessageSeverity::Error, "Conversion produced an empty output file.");
+    }
+}
+
+void inspectInput(OnlineResult& result, std::span<const std::byte> bytes, const char* sourceName, InputFormat format)
+{
+    auto context = makeInputContext(result, sourceName, fallbackSourceName(format));
+
+    const auto& input = cachedInputData(bytes, format, context, sourceName);
+    auto document = denigma::createMusxDocument<denigma::MusxReader>(input, context);
+    auto parts = document->getOthers()->getArray<musx::dom::others::PartDefinition>(musx::dom::SCORE_PARTID);
+    result.scorePageSize = pageSizeForPart(document, musx::dom::SCORE_PARTID);
+
+    int outputIndex = 1; // MusicXML callback zero is the score.
+    for (const auto& part : parts) {
+        if (part->isScore()) {
+            auto name = part->getName(musx::util::EnigmaString::AccidentalStyle::Unicode);
+            if (!name.empty()) {
+                result.scoreName = std::move(name);
+            }
+            continue;
+        }
+        auto name = part->getName(musx::util::EnigmaString::AccidentalStyle::Unicode);
+        if (name.empty()) {
+            name = "Part " + std::to_string(part->getCmper());
+        }
+        result.parts.push_back({
+            part->getCmper(),
+            std::move(name),
+            outputIndex++,
+            part->partOrder,
+            pageSizeForPart(document, part->getCmper())
+        });
+    }
+    std::stable_sort(result.parts.begin(), result.parts.end(), [](const PartInfo& lhs, const PartInfo& rhs) {
+        return lhs.partOrder < rhs.partOrder;
+    });
+}
+
+void convertMusicXml(OnlineResult& result,
+                     std::span<const std::byte> bytes,
+                     const char* sourceName,
+                     InputFormat inputFormat,
+                     bool includeTempo,
+                     bool allFontsAvailable,
+                     bool useFinaleRestPosition,
+                     int cueLayer,
+                     const int* selectedOutputs,
+                     std::size_t selectedCount)
+{
+    denigma::ConversionResult conversionResult;
+    auto context = makeConversionContext(result, sourceName, inputFormat, conversionResult);
+    context.includeTempoTool = includeTempo;
+    context.allFontsAvailable = allFontsAvailable;
+    context.useFinaleRestPosition = useFinaleRestPosition;
+    context.allPartsAndScore = true;
+    if (cueLayer > 0) {
+        context.cueLayer = cueLayer;
+    }
+
+    const std::set<int> selected(selectedOutputs, selectedOutputs + selectedCount);
+    int outputIndex = 0;
+    const auto outputCallback = [&](std::string_view suggestedName, std::span<const std::byte> data) {
+        if (selected.contains(outputIndex)) {
+            appendOutput(result, suggestedName, data, outputIndex);
+        }
+        ++outputIndex;
+    };
+    const auto& input = cachedInputData(bytes, inputFormat, context, sourceName);
+    denigma::formats::musicxml::detail::convert(input, context, outputCallback);
+    finishConversion(result, conversionResult);
+}
+
+void convertMnx(OnlineResult& result,
+                std::span<const std::byte> bytes,
+                const char* sourceName,
+                InputFormat inputFormat,
+                bool includeTempo,
+                bool splitInstruments,
+                int indentSpaces,
+                int cueLayer)
+{
+    denigma::ConversionResult conversionResult;
+    auto context = makeConversionContext(result, sourceName, inputFormat, conversionResult);
+    context.includeTempoTool = includeTempo;
+    context.mnxSplitInstruments = splitInstruments;
+    context.indentSpaces = indentSpaces < 0 ? std::nullopt : std::optional<int>(indentSpaces);
+    if (cueLayer > 0) {
+        context.cueLayer = cueLayer;
+    }
+
+    std::ostringstream output;
+    const denigma::MusxLoggerScope musxLogger(denigma::makeMusxLogCallback(context));
+    const auto& input = cachedInputData(bytes, inputFormat, context, sourceName);
+    denigma::formats::mnx::detail::exportJson(output, input, context);
+    if (!conversionResult.hasError()) {
+        appendOutput(result, {}, output.str());
+    }
+    finishConversion(result, conversionResult);
+}
+
+void convertEnigmaXml(OnlineResult& result,
+                      std::span<const std::byte> bytes,
+                      const char* sourceName,
+                      InputFormat inputFormat)
+{
+    // Denigma's MUSX-to-EnigmaXML converter writes exactly the primary buffer that
+    // extraction already produced, so both input formats reduce to the cached data.
+    auto context = makeInputContext(result, sourceName, fallbackSourceName(inputFormat));
+    const auto& input = cachedInputData(bytes, inputFormat, context, sourceName);
+    appendOutput(result, {}, primaryBytes(input));
+    if (input.primaryBuffer.empty()) {
+        addDiagnostic(result, denigma::MessageSeverity::Error, "The EnigmaXML input is empty.");
+    }
+}
+
+template <typename Callback>
+OnlineResult* makeResult(Callback&& callback)
+{
+    auto result = std::make_unique<OnlineResult>();
+    try {
+        callback(*result);
+    } catch (const std::exception& ex) {
+        addDiagnostic(*result, denigma::MessageSeverity::Error, ex.what());
+    } catch (...) {
+        addDiagnostic(*result, denigma::MessageSeverity::Error, "Unknown Denigma error.");
+    }
+    return result.release();
+}
+
+template <typename Collection>
+const typename Collection::value_type* itemAt(const Collection& collection, std::size_t index)
+{
+    return index < collection.size() ? &collection[index] : nullptr;
+}
+
+} // namespace
+
+extern "C" {
+
+void* denigma_malloc(std::size_t size) { return ::operator new(size, std::nothrow); }
+void denigma_free(void* pointer) { ::operator delete(pointer); }
+
+OnlineResult* denigma_inspect(const std::uint8_t* data, std::size_t size, const char* sourceName)
+{
+    return makeResult([&](OnlineResult& result) {
+        inspectInput(result, inputBytes(data, size), sourceName, inputFormat(sourceName));
+    });
+}
+
+OnlineResult* denigma_convert(const std::uint8_t* data,
+                           std::size_t size,
+                           const char* sourceName,
+                           int format,
+                           int includeTempo,
+                           int allFontsAvailable,
+                           int useFinaleRestPosition,
+                           int splitInstruments,
+                           int indentSpaces,
+                           int cueLayer,
+                           const int* selectedOutputs,
+                           std::size_t selectedCount)
+{
+    return makeResult([&](OnlineResult& result) {
+        const auto bytes = inputBytes(data, size);
+        const auto sourceFormat = inputFormat(sourceName);
+        switch (format) {
+        case 0:
+            if (!selectedOutputs || selectedCount == 0) {
+                throw std::invalid_argument("Select the score or at least one linked part.");
+            }
+            convertMusicXml(result, bytes, sourceName, sourceFormat, includeTempo != 0,
+                            allFontsAvailable != 0, useFinaleRestPosition != 0, cueLayer, selectedOutputs, selectedCount);
+            break;
+        case 1:
+            convertMnx(result, bytes, sourceName, sourceFormat, includeTempo != 0, splitInstruments != 0, indentSpaces, cueLayer);
+            break;
+        case 2:
+            convertEnigmaXml(result, bytes, sourceName, sourceFormat);
+            break;
+        default:
+            throw std::invalid_argument("Unknown output format.");
+        }
+    });
+}
+
+void denigma_result_destroy(OnlineResult* result) { delete result; }
+int denigma_result_success(const OnlineResult* result) { return result && result->success ? 1 : 0; }
+
+std::size_t denigma_result_diagnostic_count(const OnlineResult* result)
+{
+    return result ? result->diagnostics.size() : 0;
+}
+
+int denigma_result_diagnostic_severity(const OnlineResult* result, std::size_t index)
+{
+    const auto* item = result ? itemAt(result->diagnostics, index) : nullptr;
+    return item ? static_cast<int>(item->severity) : static_cast<int>(denigma::MessageSeverity::Error);
+}
+
+const char* denigma_result_diagnostic_message(const OnlineResult* result, std::size_t index)
+{
+    const auto* item = result ? itemAt(result->diagnostics, index) : nullptr;
+    return item ? item->message.c_str() : "";
+}
+
+const char* denigma_result_score_name(const OnlineResult* result)
+{
+    return result ? result->scoreName.c_str() : "Score";
+}
+
+double denigma_result_score_page_width_mm(const OnlineResult* result)
+{
+    return result ? result->scorePageSize.widthMm : 0.0;
+}
+
+double denigma_result_score_page_height_mm(const OnlineResult* result)
+{
+    return result ? result->scorePageSize.heightMm : 0.0;
+}
+
+double denigma_result_score_spatium_mm(const OnlineResult* result)
+{
+    return result ? result->scorePageSize.spatiumMm : 0.0;
+}
+
+int denigma_result_score_has_page_margins(const OnlineResult* result)
+{
+    return result && result->scorePageSize.hasMargins ? 1 : 0;
+}
+
+double denigma_result_score_page_margin_top_sp(const OnlineResult* result)
+{
+    return result ? result->scorePageSize.marginTopSp : 0.0;
+}
+
+double denigma_result_score_page_margin_bottom_sp(const OnlineResult* result)
+{
+    return result ? result->scorePageSize.marginBottomSp : 0.0;
+}
+
+double denigma_result_score_page_margin_left_sp(const OnlineResult* result)
+{
+    return result ? result->scorePageSize.marginLeftSp : 0.0;
+}
+
+double denigma_result_score_page_margin_right_sp(const OnlineResult* result)
+{
+    return result ? result->scorePageSize.marginRightSp : 0.0;
+}
+
+std::size_t denigma_result_part_count(const OnlineResult* result) { return result ? result->parts.size() : 0; }
+
+int denigma_result_part_id(const OnlineResult* result, std::size_t index)
+{
+    const auto* item = result ? itemAt(result->parts, index) : nullptr;
+    return item ? item->id : 0;
+}
+
+const char* denigma_result_part_name(const OnlineResult* result, std::size_t index)
+{
+    const auto* item = result ? itemAt(result->parts, index) : nullptr;
+    return item ? item->name.c_str() : "";
+}
+
+int denigma_result_part_output_index(const OnlineResult* result, std::size_t index)
+{
+    const auto* item = result ? itemAt(result->parts, index) : nullptr;
+    return item ? item->outputIndex : -1;
+}
+
+double denigma_result_part_page_width_mm(const OnlineResult* result, std::size_t index)
+{
+    const auto* item = result ? itemAt(result->parts, index) : nullptr;
+    return item ? item->pageSize.widthMm : 0.0;
+}
+
+double denigma_result_part_page_height_mm(const OnlineResult* result, std::size_t index)
+{
+    const auto* item = result ? itemAt(result->parts, index) : nullptr;
+    return item ? item->pageSize.heightMm : 0.0;
+}
+
+double denigma_result_part_spatium_mm(const OnlineResult* result, std::size_t index)
+{
+    const auto* item = result ? itemAt(result->parts, index) : nullptr;
+    return item ? item->pageSize.spatiumMm : 0.0;
+}
+
+int denigma_result_part_has_page_margins(const OnlineResult* result, std::size_t index)
+{
+    const auto* item = result ? itemAt(result->parts, index) : nullptr;
+    return item && item->pageSize.hasMargins ? 1 : 0;
+}
+
+double denigma_result_part_page_margin_top_sp(const OnlineResult* result, std::size_t index)
+{
+    const auto* item = result ? itemAt(result->parts, index) : nullptr;
+    return item ? item->pageSize.marginTopSp : 0.0;
+}
+
+double denigma_result_part_page_margin_bottom_sp(const OnlineResult* result, std::size_t index)
+{
+    const auto* item = result ? itemAt(result->parts, index) : nullptr;
+    return item ? item->pageSize.marginBottomSp : 0.0;
+}
+
+double denigma_result_part_page_margin_left_sp(const OnlineResult* result, std::size_t index)
+{
+    const auto* item = result ? itemAt(result->parts, index) : nullptr;
+    return item ? item->pageSize.marginLeftSp : 0.0;
+}
+
+double denigma_result_part_page_margin_right_sp(const OnlineResult* result, std::size_t index)
+{
+    const auto* item = result ? itemAt(result->parts, index) : nullptr;
+    return item ? item->pageSize.marginRightSp : 0.0;
+}
+
+std::size_t denigma_result_output_count(const OnlineResult* result) { return result ? result->outputs.size() : 0; }
+
+const char* denigma_result_output_name(const OnlineResult* result, std::size_t index)
+{
+    const auto* item = result ? itemAt(result->outputs, index) : nullptr;
+    return item ? item->name.c_str() : "";
+}
+
+const std::uint8_t* denigma_result_output_data(const OnlineResult* result, std::size_t index)
+{
+    const auto* item = result ? itemAt(result->outputs, index) : nullptr;
+    return item && !item->data.empty() ? item->data.data() : nullptr;
+}
+
+std::size_t denigma_result_output_size(const OnlineResult* result, std::size_t index)
+{
+    const auto* item = result ? itemAt(result->outputs, index) : nullptr;
+    return item ? item->data.size() : 0;
+}
+
+int denigma_result_output_index(const OnlineResult* result, std::size_t index)
+{
+    const auto* item = result ? itemAt(result->outputs, index) : nullptr;
+    return item ? item->sourceIndex : -1;
+}
+
+const char* denigma_version() { return DENIGMA_VERSION; }
+const char* denigma_commit() { return denigma::gitCommit(); }
+
+} // extern "C"

--- a/tests/wasm/smoke.mjs
+++ b/tests/wasm/smoke.mjs
@@ -1,0 +1,216 @@
+// Copyright 2026 Robert G. Patterson.
+// SPDX-License-Identifier: MIT
+//
+// Exercises the WebAssembly module's C ABI end to end: inspection, every
+// exporter, linked-part selection, EnigmaXML and zipped EnigmaXML input, and
+// diagnostic reporting for invalid input. It has no dependencies beyond Node.
+//
+// usage: node tests/wasm/smoke.mjs <denigma.js> <denigma.wasm> [sample.musx]
+
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const defaultSample = resolve(import.meta.dirname, '..', 'data', 'inputs', 'voiced_parts.musx');
+const [, , moduleArg, wasmArg, musxArg = defaultSample] = process.argv;
+if (!moduleArg || !wasmArg) {
+  console.error('usage: node tests/wasm/smoke.mjs <denigma.js> <denigma.wasm> [sample.musx]');
+  process.exit(2);
+}
+
+// Output format and diagnostic severity codes from the C ABI in src/wasm/denigma_wasm.cpp.
+const FORMAT_MUSICXML = 0;
+const FORMAT_MNX = 1;
+const FORMAT_ENIGMAXML = 2;
+const SEVERITY_VERBOSE = 3;
+const MNX_INDENT_SPACES = 2;
+
+const createModule = (await import(pathToFileURL(resolve(moduleArg)))).default;
+const Module = await createModule({ wasmBinary: await readFile(resolve(wasmArg)) });
+
+console.log(`denigma ${Module.UTF8ToString(Module._denigma_version())} (${Module.UTF8ToString(Module._denigma_commit())})`);
+
+function messages(result) {
+  const count = Module._denigma_result_diagnostic_count(result);
+  return Array.from({ length: count }, (_, index) =>
+    Module.UTF8ToString(Module._denigma_result_diagnostic_message(result, index))).join('\n');
+}
+
+function withAllocated(bytes, callback) {
+  const pointer = Module._denigma_malloc(bytes.byteLength);
+  Module.HEAPU8.set(bytes, pointer);
+  try {
+    return callback(pointer);
+  } finally {
+    Module._denigma_free(pointer);
+  }
+}
+
+function withInput(bytes, name, callback) {
+  return withAllocated(bytes, (dataPointer) =>
+    withAllocated(new TextEncoder().encode(`${name}\0`), (namePointer) => callback(dataPointer, namePointer)));
+}
+
+function withSelection(indices, callback) {
+  const bytes = new Uint8Array(new Int32Array(indices).buffer);
+  return withAllocated(bytes, (pointer) => callback(pointer, indices.length));
+}
+
+function convert(dataPointer, size, namePointer, format, options = {}) {
+  const { includeTempo = 0, allFonts = 0, finaleRestPosition = 0, splitInstruments = 0, cueLayer = 0, selection = [] } = options;
+  return withSelection(selection, (selectionPointer, selectionCount) =>
+    Module._denigma_convert(dataPointer, size, namePointer, format, includeTempo, allFonts, finaleRestPosition,
+      splitInstruments, MNX_INDENT_SPACES, cueLayer, selectionCount ? selectionPointer : 0, selectionCount));
+}
+
+function assertResult(result, label, marker, { outputCount = 1, verbose = false, indices } = {}) {
+  let firstOutput;
+  try {
+    if (!Module._denigma_result_success(result)) throw new Error(`${label} failed:\n${messages(result)}`);
+    if (verbose) {
+      const count = Module._denigma_result_diagnostic_count(result);
+      const severities = Array.from({ length: count }, (_, index) => Module._denigma_result_diagnostic_severity(result, index));
+      if (!severities.includes(SEVERITY_VERBOSE)) throw new Error(`${label} did not return verbose diagnostics`);
+    }
+    const actualCount = Module._denigma_result_output_count(result);
+    if (actualCount !== outputCount) throw new Error(`${label} produced ${actualCount} outputs; expected ${outputCount}`);
+    if (indices) {
+      const actual = Array.from({ length: actualCount }, (_, index) => Module._denigma_result_output_index(result, index));
+      if (actual.some((value, index) => value !== indices[index])) {
+        throw new Error(`${label} output indices were ${actual}; expected ${indices}`);
+      }
+    }
+    const pointer = Module._denigma_result_output_data(result, 0);
+    const size = Module._denigma_result_output_size(result, 0);
+    firstOutput = Module.HEAPU8.slice(pointer, pointer + size);
+    if (!new TextDecoder().decode(firstOutput).includes(marker)) throw new Error(`${label} output did not include ${marker}`);
+    console.log(`${label}: ${size} bytes`);
+  } finally {
+    Module._denigma_result_destroy(result);
+  }
+  return firstOutput;
+}
+
+function assertPageMetrics(label, width, height, spatium, hasMargins) {
+  if (width <= 0 || height <= 0 || spatium <= 0) throw new Error(`${label} returned no page metrics`);
+  if (hasMargins !== 1) throw new Error(`${label} returned no page margins`);
+}
+
+function inspect(dataPointer, size, namePointer, label) {
+  const inspection = Module._denigma_inspect(dataPointer, size, namePointer);
+  try {
+    if (!Module._denigma_result_success(inspection)) throw new Error(`${label} failed:\n${messages(inspection)}`);
+    const scoreName = Module.UTF8ToString(Module._denigma_result_score_name(inspection));
+    if (!scoreName) throw new Error(`${label} returned no score name or fallback`);
+    assertPageMetrics(`${label} score`,
+      Module._denigma_result_score_page_width_mm(inspection),
+      Module._denigma_result_score_page_height_mm(inspection),
+      Module._denigma_result_score_spatium_mm(inspection),
+      Module._denigma_result_score_has_page_margins(inspection));
+    const margins = [
+      Module._denigma_result_score_page_margin_top_sp(inspection),
+      Module._denigma_result_score_page_margin_bottom_sp(inspection),
+      Module._denigma_result_score_page_margin_left_sp(inspection),
+      Module._denigma_result_score_page_margin_right_sp(inspection)
+    ];
+    if (margins.some((value) => !Number.isFinite(value) || value < 0)) {
+      throw new Error(`${label} returned invalid score page margins: ${margins}`);
+    }
+    const partCount = Module._denigma_result_part_count(inspection);
+    const parts = Array.from({ length: partCount }, (_, index) => {
+      assertPageMetrics(`${label} part ${index}`,
+        Module._denigma_result_part_page_width_mm(inspection, index),
+        Module._denigma_result_part_page_height_mm(inspection, index),
+        Module._denigma_result_part_spatium_mm(inspection, index),
+        Module._denigma_result_part_has_page_margins(inspection, index));
+      return {
+        id: Module._denigma_result_part_id(inspection, index),
+        name: Module.UTF8ToString(Module._denigma_result_part_name(inspection, index)),
+        outputIndex: Module._denigma_result_part_output_index(inspection, index)
+      };
+    });
+    console.log(`${label}: ${scoreName}, ${partCount} linked parts`);
+    return parts;
+  } finally {
+    Module._denigma_result_destroy(inspection);
+  }
+}
+
+// Builds a zip archive with one stored (uncompressed) entry, which is all the
+// zipped-EnigmaXML input path needs.
+function storedZip(name, data) {
+  const crcTable = Uint32Array.from({ length: 256 }, (_, index) => {
+    let value = index;
+    for (let bit = 0; bit < 8; bit += 1) value = value & 1 ? 0xedb88320 ^ (value >>> 1) : value >>> 1;
+    return value >>> 0;
+  });
+  let crc = 0xffffffff;
+  for (const byte of data) crc = crcTable[(crc ^ byte) & 0xff] ^ (crc >>> 8);
+  crc = (crc ^ 0xffffffff) >>> 0;
+
+  const nameBytes = new TextEncoder().encode(name);
+  const localHeaderSize = 30;
+  const centralHeaderSize = 46;
+  const endRecordSize = 22;
+  const bytes = new Uint8Array(localHeaderSize + nameBytes.length + data.length + centralHeaderSize + nameBytes.length + endRecordSize);
+  const view = new DataView(bytes.buffer);
+  let offset = 0;
+  const write32 = (value) => { view.setUint32(offset, value, true); offset += 4; };
+  const write16 = (value) => { view.setUint16(offset, value, true); offset += 2; };
+  const writeBytes = (value) => { bytes.set(value, offset); offset += value.length; };
+  const writeEntryFields = () => {
+    write16(20); write16(0); write16(0); write16(0); write16(0);
+    write32(crc); write32(data.length); write32(data.length); write16(nameBytes.length); write16(0);
+  };
+
+  const localOffset = offset;
+  write32(0x04034b50); writeEntryFields(); writeBytes(nameBytes); writeBytes(data);
+  const centralOffset = offset;
+  write32(0x02014b50); write16(20); writeEntryFields();
+  write16(0); write16(0); write16(0); write32(0); write32(localOffset); writeBytes(nameBytes);
+  const centralSize = offset - centralOffset;
+  write32(0x06054b50); write16(0); write16(0); write16(1); write16(1); write32(centralSize); write32(centralOffset); write16(0);
+  return bytes;
+}
+
+function exerciseEnigmaXmlInput(bytes, name, label) {
+  withInput(bytes, name, (dataPointer, namePointer) => {
+    inspect(dataPointer, bytes.byteLength, namePointer, `${label} inspection`);
+    assertResult(convert(dataPointer, bytes.byteLength, namePointer, FORMAT_MUSICXML, { selection: [0] }),
+      `${label} to MusicXML`, '<score-partwise', { indices: [0] });
+    assertResult(convert(dataPointer, bytes.byteLength, namePointer, FORMAT_MNX), `${label} to MNX`, '"mnx"');
+    assertResult(convert(dataPointer, bytes.byteLength, namePointer, FORMAT_ENIGMAXML), `${label} pass-through`, '<finale');
+  });
+}
+
+const input = await readFile(resolve(musxArg));
+withInput(input, 'sample.musx', (dataPointer, namePointer) => {
+  const size = input.byteLength;
+  const parts = inspect(dataPointer, size, namePointer, 'MUSX inspection');
+
+  assertResult(convert(dataPointer, size, namePointer, FORMAT_MUSICXML, { allFonts: 1, selection: [0] }),
+    'MusicXML with all source fonts available', '<score-partwise', { indices: [0] });
+  if (parts.length) {
+    const partIndex = parts[0].outputIndex;
+    assertResult(convert(dataPointer, size, namePointer, FORMAT_MUSICXML, { includeTempo: 1, selection: [partIndex] }),
+      'MusicXML linked part', '<score-partwise', { indices: [partIndex] });
+    assertResult(convert(dataPointer, size, namePointer, FORMAT_MUSICXML, { selection: [0, partIndex] }),
+      'MusicXML score and linked part', '<score-partwise', { outputCount: 2, indices: [0, partIndex] });
+  }
+  assertResult(convert(dataPointer, size, namePointer, FORMAT_MNX), 'MNX with verbose logging', '"mnx"', { verbose: true });
+  const enigmaXml = assertResult(convert(dataPointer, size, namePointer, FORMAT_ENIGMAXML), 'EnigmaXML', '<finale');
+
+  exerciseEnigmaXmlInput(enigmaXml, 'sample.enigmaxml', 'EnigmaXML input');
+  exerciseEnigmaXmlInput(storedZip('sample.enigmaxml', enigmaXml), 'sample.enigmaxml.zip', 'Zipped EnigmaXML input');
+
+  withInput(new Uint8Array([1, 2, 3]), 'invalid.musx', (invalidPointer, invalidNamePointer) => {
+    const invalid = Module._denigma_inspect(invalidPointer, 3, invalidNamePointer);
+    try {
+      if (Module._denigma_result_success(invalid)) throw new Error('Invalid MUSX input unexpectedly succeeded');
+      if (!messages(invalid)) throw new Error('Invalid MUSX input returned no diagnostic');
+      console.log('Invalid MUSX: rejected with diagnostics');
+    } finally {
+      Module._denigma_result_destroy(invalid);
+    }
+  });
+});


### PR DESCRIPTION
Moves the WebAssembly C ABI wrapper from denigma-online into this repository so the module is built and verified here, and so consumers (denigma-online, viritura) can take a built module rather than building it themselves.

**Build**
- `src/wasm/denigma_wasm.cpp` and `src/wasm/CMakeLists.txt` define the `denigma_wasm` target (output `denigma.js` / `denigma.wasm`), with the same link libraries, flags, and exported function list as denigma-online's target.
- New option `denigma_BUILD_WASM`, on by default under Emscripten, where `denigma_BUILD_CLI` and `denigma_BUILD_TESTING` now default off. `-fexceptions` is applied under Emscripten.
- Build the named target, not `all`: the module links only the EnigmaXML, MusicXML, and MNX converters, and naming the target keeps the text-measuring converters and their font dependencies out of the Emscripten build. Documented in README and AGENTS.md.

**Test**
- `tests/wasm/smoke.mjs`: dependency-free Node smoke test covering inspection, all three exporters, linked-part selection, EnigmaXML and zipped EnigmaXML input, and invalid-input diagnostics.

**CI**
- New `wasm` job: Emscripten 5.0.7, builds `denigma_wasm`, runs the smoke test on every push and PR; uploads the `denigma-wasm` artifact for pushes to `main`; attaches `denigma.<tag>.wasm.zip` to every published release.
- GitHub actions bumped to current majors in both workflows.

**Verified**
- Clean Emscripten build compiles only the enigmaxml/mnx/musicxml graph; the smoke test passes, and denigma-online's own smoke test against the new module matches its current build byte for byte.
- Built as a subproject of denigma-online at C++20 against this checkout (its dev-mode path).
- Native build and full test suite (465 tests) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XEPweQ3tFfuaCdxU3WoYnr
