### PR TITLE
Keep CI-built WebAssembly modules from reporting a dirty commit

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,6 +94,8 @@ jobs:
         with:
           node-version: 24
 
+      # The cache folder is relative to the workspace, which is the checkout,
+      # and actions/cache refuses paths outside it; .gitignore covers it.
       - name: Set up Emscripten
         uses: emscripten-core/setup-emsdk@v16
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,4 @@ tests/data/*
 tests/data/inputs/**/.DS_Store
 
 /build-wasm/
+/emsdk-cache/

--- a/cmake/DenigmaGitCommit.cmake
+++ b/cmake/DenigmaGitCommit.cmake
@@ -16,8 +16,9 @@ if(GIT_EXECUTABLE)
     )
     if(_denigma_git_commit_result EQUAL 0 AND _denigma_git_commit)
         set(DENIGMA_GIT_COMMIT "${_denigma_git_commit}")
+        # Only changes to tracked files mark the commit dirty.
         execute_process(
-            COMMAND "${GIT_EXECUTABLE}" -C "${DENIGMA_GIT_COMMIT_SRC_DIR}" status --porcelain
+            COMMAND "${GIT_EXECUTABLE}" -C "${DENIGMA_GIT_COMMIT_SRC_DIR}" status --porcelain --untracked-files=no
             OUTPUT_VARIABLE _denigma_git_dirty
             OUTPUT_STRIP_TRAILING_WHITESPACE
             ERROR_QUIET


### PR DESCRIPTION
## Problem

The module built by the `wasm` CI job reports `1498cface3ab-dirty` (visible in the smoke-test log of run 34700158440 and in `_denigma_commit()` of the uploaded `denigma-wasm` artifact). `setup-emsdk` installs emsdk inside the checkout at `emsdk-cache`, and `cmake/DenigmaGitCommit.cmake` treats any `git status --porcelain` output as dirty, including that untracked directory.

## Changes

- `cmake/DenigmaGitCommit.cmake`: `git status --porcelain --untracked-files=no`, so only changes to tracked files mark the commit dirty.
- `.gitignore`: ignore `/emsdk-cache/`.

## Verification

Ran the capture script in a clean clone: clean tree → `b9c4304ff7ef`; with an untracked `emsdk-cache/` → still `b9c4304ff7ef`; with an edited tracked file → `b9c4304ff7ef-dirty`. The wasm job on the previous push of this branch passed; its smoke-test line should show the commit without `-dirty`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Quorh9thW9DHs77n87Prjw
