### PR TITLE
Write a full-measure rest for empty staff measures in MNX

### DIFF
--- a/src/formats/mnx/design-decisions.md
+++ b/src/formats/mnx/design-decisions.md
@@ -21,3 +21,15 @@ The displayed equation is not lost by this. MusicXML has room for both numbers a
 MNX states a tempo as a count of one note value per minute, so the beat unit has to be a note value: a base with some number of augmentation dots. Finale's beat unit is a raw EDU duration and need not be either. `calcDurationInfoFromEdu` answers with the closest base and dot count for any duration in range rather than refusing, so the exporter spells its answer back out and compares it against the original before trusting it.
 
 A beat unit that does not survive that comparison is restated as a count of quarter notes. Nothing is lost by the restatement: MNX `bpm` is a real number as of schema version 34, and dividing by the EDUs in a quarter note divides by a power of two, which is exact in binary floating point. The same path takes a beat unit outside the range of a note value, which `calcDurationInfoFromEdu` would otherwise throw on.
+
+## Sequences
+
+### An empty staff measure is written as a full-measure rest
+
+MNX requires a part-measure to carry a `sequences` array but says nothing about what an empty array means. A reader is free to draw nothing for it, and the spec's own full-measure-rest example spells an empty bar out as a sequence with `fullMeasure` set. So a staff that exports no music in a measure gets exactly that: one sequence with empty `content` and `fullMeasure: {}`, naming its staff when the part has more than one. This matches the MusicXML exporter, which writes a `<rest measure="yes"/>` for the same measures.
+
+Whether the rest appears is decided from the staff as it stands at the start of the measure, the same way Finale decides it. "Display Rests in Empty Measures" turned off, whether on the staff or through a staff style, leaves the measure with no sequences. So does an alternate notation that replaces entries, since a measure repeat or slash region draws its own content and a blank-notation region draws nothing; the measure-repeat example in the spec likewise carries no full-measure rest. "Display Rests", which hides entered rests, is not consulted: MNX has no way to hide a rest, and the exporter already exports entered rests regardless of it. Consult it here and for entered rests if MNX ever gains a `hidden` option on rests.
+
+Cue entries are skipped by the exporter and have no MNX representation yet, so a measure holding only cues counts as empty and gets the rest its staff settings call for. Revisit this when MNX gains a cue encoding.
+
+A staff-attached fermata over an empty measure attaches to that staff's full-measure rest. A staff whose settings suppressed the rest gets one created for the fermata anyway, because MNX has nowhere else to put it.

--- a/src/formats/mnx/mnx_expressions.cpp
+++ b/src/formats/mnx/mnx_expressions.cpp
@@ -268,7 +268,7 @@ void appendDynamic(const MnxMusxMappingPtr& context, mnxdom::part::Measure& mnxM
     }
 }
 
-void attachFermata(const MnxMusxMappingPtr& context, mnxdom::part::Measure& mnxMeasure,
+void attachFermata(const MnxMusxMappingPtr& context, mnxdom::part::Measure& mnxMeasure, std::optional<int> mnxStaffNumber,
     const MusxInstance<others::MeasureExprAssign>& asgn, const denigma::classify::expression::Fermata& fermataInfo,
     const ExpressionAttachmentContext& attachment, const mnxdom::Fermata& fermata)
 {
@@ -288,14 +288,18 @@ void attachFermata(const MnxMusxMappingPtr& context, mnxdom::part::Measure& mnxM
         context->logMessage(LogMsg() << "Entry " << attachment.entryInfo->getEntry()->getEntryNumber()
             << " was not mapped to an event or full measure rest", MessageSeverity::Warning);
     } else {
-        if (mnxMeasure.sequences().empty()) {
-            mnxMeasure.sequences().append();
-        }
+        const int staffNumber = mnxStaffNumber.value_or(1);
+        bool attached = false;
         for (auto seq : mnxMeasure.sequences()) {
-            if (seq.content().empty()) {
-                auto fullMeasureRest = seq.ensure_fullMeasure();
-                fullMeasureRest.set_fermata(fermata);
+            if (seq.staff() == staffNumber && seq.content().empty()) {
+                seq.ensure_fullMeasure().set_fermata(fermata);
+                attached = true;
             }
+        }
+        if (!attached) {
+            auto seq = mnxMeasure.sequences().append();
+            seq.set_or_clear_staff(staffNumber);
+            seq.ensure_fullMeasure().set_fermata(fermata);
         }
     }
 }
@@ -350,7 +354,7 @@ void processExpressions(const MnxMusxMappingPtr& context, const MusxInstance<oth
             case classify::ExpressionType::Fermata: {
                 const auto& fermata = classification.fermata();
                 if (auto mnxFermata = makeFermata(fermata.fermata, fermata.glyphStyle, placement)) {
-                    attachFermata(context, mnxMeasure, asgn, fermata, calcAttachmentContext(context, asgn), mnxFermata.value());
+                    attachFermata(context, mnxMeasure, mnxStaffNumber, asgn, fermata, calcAttachmentContext(context, asgn), mnxFermata.value());
                 }
                 break;
             }

--- a/src/formats/mnx/mnx_sequences.cpp
+++ b/src/formats/mnx/mnx_sequences.cpp
@@ -609,7 +609,26 @@ static EntryInfoPtr::InterpretedIterator addEntryToContent(const MnxMusxMappingP
     return next;
 }
 
-void createSequences(const MnxMusxMappingPtr& context,
+/// @brief Appends the full-measure rest an empty staff measure displays, if the staff displays one.
+/// See "An empty staff measure is written as a full-measure rest" in design-decisions.md.
+static void appendEmptyMeasureRest(const MnxMusxMappingPtr& context,
+    mnxdom::part::Measure& mnxMeasure,
+    std::optional<int> mnxStaffNumber,
+    const MusxInstance<others::Measure>& musxMeasure)
+{
+    const auto musxStaff = others::StaffComposite::createCurrent(
+        musxMeasure->getDocument(), musxMeasure->getRequestedPartId(), context->current.staff, musxMeasure->getCmper(), 0);
+    // Asking about the alternate notation's own layer reduces the question to whether that notation
+    // replaces entries at all.
+    if (!musxStaff || musxStaff->blankMeasure || musxStaff->calcAlternateNotationHidesEntries(musxStaff->altLayer)) {
+        return;
+    }
+    auto sequence = mnxMeasure.sequences().append();
+    sequence.set_or_clear_staff(mnxStaffNumber.value_or(1));
+    sequence.ensure_fullMeasure();
+}
+
+static void createEntrySequences(const MnxMusxMappingPtr& context,
     mnxdom::part::Measure& mnxMeasure,
     std::optional<int> mnxStaffNumber,
     const MusxInstance<others::Measure>& musxMeasure)
@@ -652,6 +671,18 @@ void createSequences(const MnxMusxMappingPtr& context,
                 }
             }
         }
+    }
+}
+
+void createSequences(const MnxMusxMappingPtr& context,
+    mnxdom::part::Measure& mnxMeasure,
+    std::optional<int> mnxStaffNumber,
+    const MusxInstance<others::Measure>& musxMeasure)
+{
+    const size_t sequenceCountBefore = mnxMeasure.sequences().size();
+    createEntrySequences(context, mnxMeasure, mnxStaffNumber, musxMeasure);
+    if (mnxMeasure.sequences().size() == sequenceCountBefore) {
+        appendEmptyMeasureRest(context, mnxMeasure, mnxStaffNumber, musxMeasure);
     }
 }
 

--- a/tests/mnx/test_parts.cpp
+++ b/tests/mnx/test_parts.cpp
@@ -317,12 +317,15 @@ TEST(MnxParts, MeasureRepeats)
     // Alternate notation replaces the entries of the layers it hides, so those layers are not
     // exported. The fixture applies repeat styles both with and without "hide other layers", so a
     // measure is either emptied entirely or keeps the layers the style leaves alone. Measures 1
-    // through 3 hold no entries in the source at all.
-    const std::array<size_t, 14> expectedSequenceCounts = { 0, 0, 0, 0, 1, 2, 1, 1, 0, 1, 1, 0, 0, 0 };
+    // through 3 hold no entries in the source at all; only measure 1, which has no alternate
+    // notation, gets a full-measure rest.
+    const std::array<size_t, 14> expectedSequenceCounts = { 1, 0, 0, 0, 1, 2, 1, 1, 0, 1, 1, 0, 0, 0 };
     for (size_t x = 0; x < expectedSequenceCounts.size(); x++) {
         EXPECT_EQ(measures[x].sequences().size(), expectedSequenceCounts[x])
             << "measure " << (x + 1) << " sequence count";
     }
+    ASSERT_EQ(measures[0].sequences().size(), 1);
+    EXPECT_TRUE(measures[0].sequences()[0].fullMeasure().has_value()) << "measure 1 should be a full-measure rest";
 }
 
 TEST(MnxParts, MeasureRepeatCounters)

--- a/tests/mnx/test_sequences.cpp
+++ b/tests/mnx/test_sequences.cpp
@@ -195,3 +195,61 @@ TEST(MnxSequences, GraceBeamsRetainSlashState)
     EXPECT_FALSE(lastGrace.contains("slash")) << lastGrace.dump(4); // omitted means slashed
     EXPECT_EQ(lastGrace["content"].size(), 1u);
 }
+
+namespace {
+
+// Summarizes a measure's sequences as (staff, isFullMeasureRest) pairs in document order.
+std::vector<std::pair<int, bool>> summarizeSequences(const nlohmann::json& measure)
+{
+    std::vector<std::pair<int, bool>> result;
+    for (const auto& sequence : measure.value("sequences", nlohmann::json::array())) {
+        result.emplace_back(sequence.value("staff", 1), sequence.contains("fullMeasure"));
+    }
+    return result;
+}
+
+} // namespace
+
+TEST(MnxSequences, EmptyMeasuresGetFullMeasureRestPerStaff)
+{
+    const auto mnx = exportMnxFixture("voices_keyboard.musx");
+    ASSERT_TRUE(mnx.contains("parts"));
+    ASSERT_EQ(mnx["parts"].size(), 1u);
+    const auto& measures = mnx["parts"][0]["measures"];
+    ASSERT_EQ(measures.size(), 7u);
+
+    using Summary = std::vector<std::pair<int, bool>>;
+    // Measure 3 is empty on both staves of the piano part.
+    EXPECT_EQ(summarizeSequences(measures[2]), (Summary{ { 1, true }, { 2, true } })) << measures[2].dump(4);
+    // Measure 6 holds real whole-rest entries, which are exported as full-measure rests in their own right.
+    EXPECT_EQ(summarizeSequences(measures[5]), (Summary{ { 1, true }, { 2, true } })) << measures[5].dump(4);
+    // Measure 7 is empty, but staff 1 has "Display Rests in Empty Measures" off through a staff style.
+    // Staff 2 hides entered rests through "Display Rests", which does not suppress the empty-measure rest.
+    EXPECT_EQ(summarizeSequences(measures[6]), (Summary{ { 2, true } })) << measures[6].dump(4);
+}
+
+TEST(MnxSequences, EmptyMeasureRestOmitsStaffOnSingleStaffPart)
+{
+    const auto mnx = exportMnxFixture("slurs_beatattached.musx");
+    ASSERT_TRUE(mnx.contains("parts"));
+    ASSERT_EQ(mnx["parts"].size(), 2u);
+
+    // Part 1 blanks measures 2 through 4 through a staff style, so they stay empty.
+    const auto& firstPartMeasures = mnx["parts"][0]["measures"];
+    ASSERT_EQ(firstPartMeasures.size(), 4u);
+    for (size_t x = 1; x < firstPartMeasures.size(); x++) {
+        EXPECT_TRUE(firstPartMeasures[x]["sequences"].empty()) << "part 1 measure " << (x + 1) << firstPartMeasures[x].dump(4);
+    }
+
+    // Part 2 is a single-staff part, so its empty measures 3 and 4 get a rest that names no staff.
+    const auto& secondPartMeasures = mnx["parts"][1]["measures"];
+    ASSERT_EQ(secondPartMeasures.size(), 4u);
+    for (size_t x = 2; x < secondPartMeasures.size(); x++) {
+        const auto& sequences = secondPartMeasures[x]["sequences"];
+        ASSERT_EQ(sequences.size(), 1u) << "part 2 measure " << (x + 1) << secondPartMeasures[x].dump(4);
+        EXPECT_FALSE(sequences[0].contains("staff")) << sequences[0].dump(4);
+        EXPECT_FALSE(sequences[0].contains("voice")) << sequences[0].dump(4);
+        EXPECT_TRUE(sequences[0].contains("fullMeasure")) << sequences[0].dump(4);
+        EXPECT_TRUE(sequences[0]["content"].empty()) << sequences[0].dump(4);
+    }
+}


### PR DESCRIPTION
## Summary

An MNX part-measure with an empty `sequences` array does not mean a whole rest to a reader, and the spec's own full-measure-rest example spells an empty bar out as a sequence with `fullMeasure` set. Denigma now exports one such sequence per staff for every staff measure that has no music, naming the staff only when the part has more than one. This matches what the MusicXML exporter already does with `<rest measure="yes"/>`.

The rest is suppressed by the same staff settings Finale uses at the start of the measure:
- "Display Rests in Empty Measures" turned off, on the staff or through a staff style.
- An alternate notation that replaces entries (measure repeat, slash, blank notation), which draws its own content. The spec's measure-repeat example likewise carries no full-measure rest.

"Display Rests" (which hides entered rests) is not consulted, since MNX has no way to hide a rest. Cue entries are not yet representable in MNX, so a measure holding only cues counts as empty.

`attachFermata` now takes the staff number, so a staff-attached fermata over an empty measure lands only on that staff's full-measure rest rather than on every content-empty sequence in the measure.

The policy is recorded in `src/formats/mnx/design-decisions.md`.

## Tests

- `MnxParts.MeasureRepeats`: measure 1 (empty, no alternate notation) now expects a full-measure rest; the alternate-notation measures stay empty.
- New `MnxSequences.EmptyMeasuresGetFullMeasureRestPerStaff` (`voices_keyboard.musx`): both staves get a rest in an empty measure; a staff style with "Display Rests in Empty Measures" off suppresses it on one staff.
- New `MnxSequences.EmptyMeasureRestOmitsStaffOnSingleStaffPart` (`slurs_beatattached.musx`): a blank-style part stays empty; a single-staff part's rest omits `staff` and `voice`.

Full suite: 467 tests pass. All fixture MNX outputs still validate; the only semantic errors (missing initial clefs in `tempo_varied_staves` and `large_orchestra`) predate this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014RCtC27THoeEAR6fFMX71n
